### PR TITLE
docs: /backend/CLAUDE.md 파일 수정

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -58,15 +58,15 @@ Follow team conventions:
 
 ## 5) API design guardrails
 
-* Always output **API list → DTOs → DB tables → errors → implementation steps → tests** before writing code.
-* Use consistent error responses and `@RestControllerAdvice`.
-* Use `@Valid` and Bean Validation on request DTOs.
+* Workflow: Always output API list → DTOs → DB tables → errors → implementation steps → tests before writing code.
+* Controller Cleanliness: To prevent controllers from becoming bloated, separate Swagger annotations into an Interface. The Controller should only contain business logic mapping.
+* Validation: Use @Valid and Bean Validation on request DTOs.
+* Global Handling: Use consistent error responses via @RestControllerAdvice.
 * Swagger/OpenAPI rules:
 
-  * Add `@Tag(name = "...")` per controller group
-  * Document endpoints using `@Operation(summary = "...", description = "...")`
-  * For request/response examples: use `@Schema(example = "...")` on DTO fields
-  * If auth is required: mark with `@SecurityRequirement(name = "bearerAuth")`
+  * Abstraction: Define @Tag, @Operation, and @ApiResponses in the API interface.
+  * Schema Documentation: Use @Schema(example = "...") on DTO fields for frontend clarity.
+  * Security: Mark authenticated endpoints with @SecurityRequirement(name = "bearerAuth").
 
 ✅ Swagger UI location (default):
 


### PR DESCRIPTION
## 관련 이슈
Closes #1 

## 변경 내용 
API 설계 가이드라인에 '인터페이스 기반의 Swagger 설정 분리' 원칙을 추가

1. API 명세와 구현의 분리 (Separation of Concerns)
기존 문제점: 컨트롤러 메서드 위에 @Operation, @ApiResponse 등 수많은 Swagger 어노테이션이 추가되면서 실제 비즈니스 로직(컨트롤러 코드)을 파악하기가 어려워지는 '코드 비대화' 현상이 발생 가능

해결책: Interface에 Swagger 어노테이션을 몰아넣어 API 명세서 역할을 하게 하고, Controller는 이를 상속받아 순수 로직 구현에만 집중하도록 CLAUDE.md 수정

---

- Interface만 확인해도 API의 명세(기능, 응답 값, 에러 케이스)를 한눈에 파악 가능
- @Schema(example = "...") 사용을 의무화하여 API 연결 시 즉시 참고할 수 있는 샘플을 제공

