### PR TITLE
마이그레이션 소유권 검증 및 리딤 OTP step-up 인증 추가

### DIFF
--- a/backend/src/main/java/com/project/kkookk/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/project/kkookk/global/exception/ErrorCode.java
@@ -85,6 +85,7 @@ public enum ErrorCode {
             HttpStatus.PAYLOAD_TOO_LARGE, "MIGRATION_IMAGE_TOO_LARGE", "이미지 크기가 너무 큽니다 (최대 5MB)"),
 
     // Redeem
+    STEPUP_REQUIRED(HttpStatus.FORBIDDEN, "STEPUP_REQUIRED", "OTP 인증이 필요합니다"),
     REWARD_NOT_FOUND(HttpStatus.NOT_FOUND, "REWARD_NOT_FOUND", "리워드를 찾을 수 없습니다"),
     REWARD_NOT_AVAILABLE(HttpStatus.CONFLICT, "REWARD_NOT_AVAILABLE", "사용 가능한 리워드가 아닙니다"),
     REDEEM_SESSION_ALREADY_EXISTS(

--- a/backend/src/main/java/com/project/kkookk/migration/controller/OwnerMigrationApi.java
+++ b/backend/src/main/java/com/project/kkookk/migration/controller/OwnerMigrationApi.java
@@ -1,6 +1,7 @@
 package com.project.kkookk.migration.controller;
 
 import com.project.kkookk.global.exception.ErrorResponse;
+import com.project.kkookk.global.security.OwnerPrincipal;
 import com.project.kkookk.migration.controller.dto.MigrationApproveRequest;
 import com.project.kkookk.migration.controller.dto.MigrationApproveResponse;
 import com.project.kkookk.migration.controller.dto.MigrationDetailResponse;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -33,7 +35,8 @@ public interface OwnerMigrationApi {
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<MigrationListResponse> getList(
-            @Parameter(description = "매장 ID", required = true) @PathVariable Long storeId);
+            @Parameter(description = "매장 ID", required = true) @PathVariable Long storeId,
+            @Parameter(hidden = true) @AuthenticationPrincipal OwnerPrincipal principal);
 
     @Operation(summary = "마이그레이션 요청 상세 조회", description = "마이그레이션 요청의 상세 정보를 조회합니다.")
     @ApiResponses({
@@ -49,7 +52,8 @@ public interface OwnerMigrationApi {
     })
     ResponseEntity<MigrationDetailResponse> getDetail(
             @Parameter(description = "매장 ID", required = true) @PathVariable Long storeId,
-            @Parameter(description = "마이그레이션 요청 ID", required = true) @PathVariable Long id);
+            @Parameter(description = "마이그레이션 요청 ID", required = true) @PathVariable Long id,
+            @Parameter(hidden = true) @AuthenticationPrincipal OwnerPrincipal principal);
 
     @Operation(
             summary = "마이그레이션 승인",
@@ -78,7 +82,8 @@ public interface OwnerMigrationApi {
     ResponseEntity<MigrationApproveResponse> approve(
             @Parameter(description = "매장 ID", required = true) @PathVariable Long storeId,
             @Parameter(description = "마이그레이션 요청 ID", required = true) @PathVariable Long id,
-            @Valid @RequestBody MigrationApproveRequest request);
+            @Valid @RequestBody MigrationApproveRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal OwnerPrincipal principal);
 
     @Operation(summary = "마이그레이션 반려", description = "마이그레이션 요청을 반려합니다.")
     @ApiResponses({
@@ -103,5 +108,6 @@ public interface OwnerMigrationApi {
     ResponseEntity<MigrationRejectResponse> reject(
             @Parameter(description = "매장 ID", required = true) @PathVariable Long storeId,
             @Parameter(description = "마이그레이션 요청 ID", required = true) @PathVariable Long id,
-            @Valid @RequestBody MigrationRejectRequest request);
+            @Valid @RequestBody MigrationRejectRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal OwnerPrincipal principal);
 }

--- a/backend/src/main/java/com/project/kkookk/migration/controller/OwnerMigrationController.java
+++ b/backend/src/main/java/com/project/kkookk/migration/controller/OwnerMigrationController.java
@@ -1,5 +1,6 @@
 package com.project.kkookk.migration.controller;
 
+import com.project.kkookk.global.security.OwnerPrincipal;
 import com.project.kkookk.migration.controller.dto.MigrationApproveRequest;
 import com.project.kkookk.migration.controller.dto.MigrationApproveResponse;
 import com.project.kkookk.migration.controller.dto.MigrationDetailResponse;
@@ -9,6 +10,7 @@ import com.project.kkookk.migration.controller.dto.MigrationRejectResponse;
 import com.project.kkookk.migration.service.OwnerMigrationService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,16 +30,21 @@ public class OwnerMigrationController implements OwnerMigrationApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<MigrationListResponse> getList(@PathVariable Long storeId) {
-        MigrationListResponse response = ownerMigrationService.getList(storeId);
+    public ResponseEntity<MigrationListResponse> getList(
+            @PathVariable Long storeId, @AuthenticationPrincipal OwnerPrincipal principal) {
+        MigrationListResponse response =
+                ownerMigrationService.getList(storeId, principal.getOwnerId());
         return ResponseEntity.ok(response);
     }
 
     @Override
     @GetMapping("/{id}")
     public ResponseEntity<MigrationDetailResponse> getDetail(
-            @PathVariable Long storeId, @PathVariable Long id) {
-        MigrationDetailResponse response = ownerMigrationService.getDetail(storeId, id);
+            @PathVariable Long storeId,
+            @PathVariable Long id,
+            @AuthenticationPrincipal OwnerPrincipal principal) {
+        MigrationDetailResponse response =
+                ownerMigrationService.getDetail(storeId, id, principal.getOwnerId());
         return ResponseEntity.ok(response);
     }
 
@@ -46,8 +53,10 @@ public class OwnerMigrationController implements OwnerMigrationApi {
     public ResponseEntity<MigrationApproveResponse> approve(
             @PathVariable Long storeId,
             @PathVariable Long id,
-            @Valid @RequestBody MigrationApproveRequest request) {
-        MigrationApproveResponse response = ownerMigrationService.approve(storeId, id, request);
+            @Valid @RequestBody MigrationApproveRequest request,
+            @AuthenticationPrincipal OwnerPrincipal principal) {
+        MigrationApproveResponse response =
+                ownerMigrationService.approve(storeId, id, request, principal.getOwnerId());
         return ResponseEntity.ok(response);
     }
 
@@ -56,8 +65,10 @@ public class OwnerMigrationController implements OwnerMigrationApi {
     public ResponseEntity<MigrationRejectResponse> reject(
             @PathVariable Long storeId,
             @PathVariable Long id,
-            @Valid @RequestBody MigrationRejectRequest request) {
-        MigrationRejectResponse response = ownerMigrationService.reject(storeId, id, request);
+            @Valid @RequestBody MigrationRejectRequest request,
+            @AuthenticationPrincipal OwnerPrincipal principal) {
+        MigrationRejectResponse response =
+                ownerMigrationService.reject(storeId, id, request, principal.getOwnerId());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/project/kkookk/migration/service/OwnerMigrationService.java
+++ b/backend/src/main/java/com/project/kkookk/migration/service/OwnerMigrationService.java
@@ -18,6 +18,7 @@ import com.project.kkookk.stamp.repository.StampEventRepository;
 import com.project.kkookk.stampcard.domain.StampCard;
 import com.project.kkookk.stampcard.domain.StampCardStatus;
 import com.project.kkookk.stampcard.repository.StampCardRepository;
+import com.project.kkookk.store.repository.StoreRepository;
 import com.project.kkookk.wallet.domain.CustomerWallet;
 import com.project.kkookk.wallet.domain.WalletStampCard;
 import com.project.kkookk.wallet.repository.CustomerWalletRepository;
@@ -39,21 +40,26 @@ public class OwnerMigrationService {
     private final WalletStampCardRepository walletStampCardRepository;
     private final StampCardRepository stampCardRepository;
     private final StampEventRepository stampEventRepository;
+    private final StoreRepository storeRepository;
 
     public OwnerMigrationService(
             StampMigrationRequestRepository migrationRepository,
             CustomerWalletRepository customerWalletRepository,
             WalletStampCardRepository walletStampCardRepository,
             StampCardRepository stampCardRepository,
-            StampEventRepository stampEventRepository) {
+            StampEventRepository stampEventRepository,
+            StoreRepository storeRepository) {
         this.migrationRepository = migrationRepository;
         this.customerWalletRepository = customerWalletRepository;
         this.walletStampCardRepository = walletStampCardRepository;
         this.stampCardRepository = stampCardRepository;
         this.stampEventRepository = stampEventRepository;
+        this.storeRepository = storeRepository;
     }
 
-    public MigrationListResponse getList(Long storeId) {
+    public MigrationListResponse getList(Long storeId, Long ownerId) {
+        validateStoreOwnership(storeId, ownerId);
+
         List<StampMigrationRequest> migrations =
                 migrationRepository.findByStoreIdAndStatusOrderByRequestedAtDesc(
                         storeId, StampMigrationStatus.SUBMITTED);
@@ -76,7 +82,7 @@ public class OwnerMigrationService {
                                             m.getId(),
                                             wallet != null ? wallet.getPhone() : null,
                                             wallet != null ? wallet.getName() : null,
-                                            m.getImageData(),
+                                            null, // 목록에서는 이미지 제외 (성능/보안)
                                             m.getStatus().name(),
                                             m.getRequestedAt());
                                 })
@@ -85,7 +91,8 @@ public class OwnerMigrationService {
         return new MigrationListResponse(summaries);
     }
 
-    public MigrationDetailResponse getDetail(Long storeId, Long migrationId) {
+    public MigrationDetailResponse getDetail(Long storeId, Long migrationId, Long ownerId) {
+        validateStoreOwnership(storeId, ownerId);
         StampMigrationRequest migration = findMigrationByIdAndStoreId(migrationId, storeId);
 
         CustomerWallet wallet =
@@ -110,7 +117,8 @@ public class OwnerMigrationService {
 
     @Transactional
     public MigrationApproveResponse approve(
-            Long storeId, Long migrationId, MigrationApproveRequest request) {
+            Long storeId, Long migrationId, MigrationApproveRequest request, Long ownerId) {
+        validateStoreOwnership(storeId, ownerId);
         StampMigrationRequest migration = findMigrationByIdAndStoreId(migrationId, storeId);
 
         if (!migration.isSubmitted()) {
@@ -126,10 +134,11 @@ public class OwnerMigrationService {
                                 storeId, StampCardStatus.ACTIVE)
                         .orElseThrow(() -> new BusinessException(ErrorCode.NO_ACTIVE_STAMP_CARD));
 
-        // WalletStampCard 조회 (마이그레이션은 지갑 카드 등록 이후에만 가능)
+        // WalletStampCard 조회 (비관적 락으로 동시성 제어)
         WalletStampCard walletStampCard =
                 walletStampCardRepository
-                        .findByCustomerWalletIdAndStoreId(migration.getCustomerWalletId(), storeId)
+                        .findByCustomerWalletIdAndStoreIdWithLock(
+                                migration.getCustomerWalletId(), storeId)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.WALLET_STAMP_CARD_NOT_FOUND));
 
@@ -162,7 +171,8 @@ public class OwnerMigrationService {
 
     @Transactional
     public MigrationRejectResponse reject(
-            Long storeId, Long migrationId, MigrationRejectRequest request) {
+            Long storeId, Long migrationId, MigrationRejectRequest request, Long ownerId) {
+        validateStoreOwnership(storeId, ownerId);
         StampMigrationRequest migration = findMigrationByIdAndStoreId(migrationId, storeId);
 
         if (!migration.isSubmitted()) {
@@ -182,5 +192,11 @@ public class OwnerMigrationService {
         return migrationRepository
                 .findByIdAndStoreId(migrationId, storeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MIGRATION_NOT_FOUND));
+    }
+
+    private void validateStoreOwnership(Long storeId, Long ownerId) {
+        storeRepository
+                .findByIdAndOwnerAccountId(storeId, ownerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACCESS_DENIED));
     }
 }

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/CustomerRedeemController.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/CustomerRedeemController.java
@@ -1,5 +1,7 @@
 package com.project.kkookk.redeem.controller;
 
+import com.project.kkookk.global.exception.BusinessException;
+import com.project.kkookk.global.exception.ErrorCode;
 import com.project.kkookk.global.security.CustomerPrincipal;
 import com.project.kkookk.redeem.controller.dto.CreateRedeemSessionRequest;
 import com.project.kkookk.redeem.controller.dto.RedeemSessionResponse;
@@ -27,6 +29,11 @@ public class CustomerRedeemController implements CustomerRedeemApi {
     public ResponseEntity<RedeemSessionResponse> createRedeemSession(
             @Valid @RequestBody CreateRedeemSessionRequest request,
             @AuthenticationPrincipal CustomerPrincipal principal) {
+
+        // OTP step-up 인증 필수
+        if (!principal.isStepUp()) {
+            throw new BusinessException(ErrorCode.STEPUP_REQUIRED);
+        }
 
         RedeemSessionResponse response =
                 customerRedeemService.createRedeemSession(principal.getWalletId(), request);

--- a/backend/src/main/java/com/project/kkookk/wallet/repository/WalletStampCardRepository.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/repository/WalletStampCardRepository.java
@@ -27,4 +27,12 @@ public interface WalletStampCardRepository extends JpaRepository<WalletStampCard
 
     /** 매장별 고객 지갑 스탬프카드 조회 */
     Optional<WalletStampCard> findByCustomerWalletIdAndStoreId(Long customerWalletId, Long storeId);
+
+    /** 매장별 고객 지갑 스탬프카드 조회 (비관적 락) */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+            "SELECT w FROM WalletStampCard w "
+                    + "WHERE w.customerWalletId = :customerWalletId AND w.storeId = :storeId")
+    Optional<WalletStampCard> findByCustomerWalletIdAndStoreIdWithLock(
+            @Param("customerWalletId") Long customerWalletId, @Param("storeId") Long storeId);
 }

--- a/backend/src/test/java/com/project/kkookk/migration/controller/OwnerMigrationControllerTest.java
+++ b/backend/src/test/java/com/project/kkookk/migration/controller/OwnerMigrationControllerTest.java
@@ -84,7 +84,7 @@ class OwnerMigrationControllerTest {
 
             MigrationListResponse response = new MigrationListResponse(List.of(summary));
 
-            given(ownerMigrationService.getList(storeId)).willReturn(response);
+            given(ownerMigrationService.getList(eq(storeId), any(Long.class))).willReturn(response);
 
             // when & then
             mockMvc.perform(get("/api/owner/stores/{storeId}/migrations", storeId))
@@ -102,7 +102,7 @@ class OwnerMigrationControllerTest {
             Long storeId = 1L;
             MigrationListResponse response = new MigrationListResponse(List.of());
 
-            given(ownerMigrationService.getList(storeId)).willReturn(response);
+            given(ownerMigrationService.getList(eq(storeId), any(Long.class))).willReturn(response);
 
             // when & then
             mockMvc.perform(get("/api/owner/stores/{storeId}/migrations", storeId))
@@ -137,7 +137,8 @@ class OwnerMigrationControllerTest {
                             requestedAt,
                             null);
 
-            given(ownerMigrationService.getDetail(storeId, migrationId)).willReturn(response);
+            given(ownerMigrationService.getDetail(eq(storeId), eq(migrationId), any(Long.class)))
+                    .willReturn(response);
 
             // when & then
             mockMvc.perform(
@@ -158,7 +159,7 @@ class OwnerMigrationControllerTest {
             Long storeId = 1L;
             Long migrationId = 999L;
 
-            given(ownerMigrationService.getDetail(storeId, migrationId))
+            given(ownerMigrationService.getDetail(eq(storeId), eq(migrationId), any(Long.class)))
                     .willThrow(new BusinessException(ErrorCode.MIGRATION_NOT_FOUND));
 
             // when & then
@@ -194,7 +195,8 @@ class OwnerMigrationControllerTest {
                             ownerMigrationService.approve(
                                     eq(storeId),
                                     eq(migrationId),
-                                    any(MigrationApproveRequest.class)))
+                                    any(MigrationApproveRequest.class),
+                                    any(Long.class)))
                     .willReturn(response);
 
             // when & then
@@ -243,7 +245,8 @@ class OwnerMigrationControllerTest {
                             ownerMigrationService.approve(
                                     eq(storeId),
                                     eq(migrationId),
-                                    any(MigrationApproveRequest.class)))
+                                    any(MigrationApproveRequest.class),
+                                    any(Long.class)))
                     .willThrow(new BusinessException(ErrorCode.MIGRATION_ALREADY_PROCESSED));
 
             // when & then
@@ -270,7 +273,8 @@ class OwnerMigrationControllerTest {
                             ownerMigrationService.approve(
                                     eq(storeId),
                                     eq(migrationId),
-                                    any(MigrationApproveRequest.class)))
+                                    any(MigrationApproveRequest.class),
+                                    any(Long.class)))
                     .willThrow(new BusinessException(ErrorCode.NO_ACTIVE_STAMP_CARD));
 
             // when & then
@@ -307,7 +311,8 @@ class OwnerMigrationControllerTest {
                             ownerMigrationService.reject(
                                     eq(storeId),
                                     eq(migrationId),
-                                    any(MigrationRejectRequest.class)))
+                                    any(MigrationRejectRequest.class),
+                                    any(Long.class)))
                     .willReturn(response);
 
             // when & then
@@ -356,7 +361,8 @@ class OwnerMigrationControllerTest {
                             ownerMigrationService.reject(
                                     eq(storeId),
                                     eq(migrationId),
-                                    any(MigrationRejectRequest.class)))
+                                    any(MigrationRejectRequest.class),
+                                    any(Long.class)))
                     .willThrow(new BusinessException(ErrorCode.MIGRATION_ALREADY_PROCESSED));
 
             // when & then

--- a/backend/src/test/java/com/project/kkookk/migration/service/OwnerMigrationServiceTest.java
+++ b/backend/src/test/java/com/project/kkookk/migration/service/OwnerMigrationServiceTest.java
@@ -22,6 +22,9 @@ import com.project.kkookk.stamp.repository.StampEventRepository;
 import com.project.kkookk.stampcard.domain.StampCard;
 import com.project.kkookk.stampcard.domain.StampCardStatus;
 import com.project.kkookk.stampcard.repository.StampCardRepository;
+import com.project.kkookk.store.domain.Store;
+import com.project.kkookk.store.domain.StoreStatus;
+import com.project.kkookk.store.repository.StoreRepository;
 import com.project.kkookk.wallet.domain.CustomerWallet;
 import com.project.kkookk.wallet.domain.WalletStampCard;
 import com.project.kkookk.wallet.repository.CustomerWalletRepository;
@@ -42,6 +45,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OwnerMigrationServiceTest {
 
+    private static final Long OWNER_ID = 1L;
+
     @InjectMocks private OwnerMigrationService ownerMigrationService;
 
     @Mock private StampMigrationRequestRepository migrationRepository;
@@ -49,6 +54,7 @@ class OwnerMigrationServiceTest {
     @Mock private WalletStampCardRepository walletStampCardRepository;
     @Mock private StampCardRepository stampCardRepository;
     @Mock private StampEventRepository stampEventRepository;
+    @Mock private StoreRepository storeRepository;
 
     @Nested
     @DisplayName("목록 조회")
@@ -63,7 +69,10 @@ class OwnerMigrationServiceTest {
 
             StampMigrationRequest migration = createMigration(1L, walletId, storeId);
             CustomerWallet wallet = createWallet(walletId, "010-1234-5678", "홍길동");
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(
                             migrationRepository.findByStoreIdAndStatusOrderByRequestedAtDesc(
                                     storeId, StampMigrationStatus.SUBMITTED))
@@ -72,13 +81,14 @@ class OwnerMigrationServiceTest {
                     .willReturn(List.of(wallet));
 
             // when
-            MigrationListResponse response = ownerMigrationService.getList(storeId);
+            MigrationListResponse response = ownerMigrationService.getList(storeId, OWNER_ID);
 
             // then
             assertThat(response.migrations()).hasSize(1);
             assertThat(response.migrations().get(0).customerPhone()).isEqualTo("010-1234-5678");
             assertThat(response.migrations().get(0).customerName()).isEqualTo("홍길동");
             assertThat(response.migrations().get(0).status()).isEqualTo("SUBMITTED");
+            assertThat(response.migrations().get(0).imageUrl()).isNull(); // 목록에서 이미지 제외
         }
 
         @Test
@@ -86,14 +96,17 @@ class OwnerMigrationServiceTest {
         void getList_Success_Empty() {
             // given
             Long storeId = 1L;
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(
                             migrationRepository.findByStoreIdAndStatusOrderByRequestedAtDesc(
                                     storeId, StampMigrationStatus.SUBMITTED))
                     .willReturn(List.of());
 
             // when
-            MigrationListResponse response = ownerMigrationService.getList(storeId);
+            MigrationListResponse response = ownerMigrationService.getList(storeId, OWNER_ID);
 
             // then
             assertThat(response.migrations()).isEmpty();
@@ -114,14 +127,17 @@ class OwnerMigrationServiceTest {
 
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
             CustomerWallet wallet = createWallet(walletId, "010-1234-5678", "홍길동");
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
             given(customerWalletRepository.findById(walletId)).willReturn(Optional.of(wallet));
 
             // when
             MigrationDetailResponse response =
-                    ownerMigrationService.getDetail(storeId, migrationId);
+                    ownerMigrationService.getDetail(storeId, migrationId, OWNER_ID);
 
             // then
             assertThat(response.id()).isEqualTo(migrationId);
@@ -136,12 +152,16 @@ class OwnerMigrationServiceTest {
             // given
             Long storeId = 1L;
             Long migrationId = 999L;
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.getDetail(storeId, migrationId))
+            assertThatThrownBy(
+                            () -> ownerMigrationService.getDetail(storeId, migrationId, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -166,14 +186,19 @@ class OwnerMigrationServiceTest {
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
             StampCard activeCard = createActiveStampCard(10L, storeId);
             WalletStampCard walletStampCard = createWalletStampCard(50L, walletId, storeId, 10L, 3);
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
             given(
                             stampCardRepository.findFirstByStoreIdAndStatusOrderByCreatedAtDesc(
                                     storeId, StampCardStatus.ACTIVE))
                     .willReturn(Optional.of(activeCard));
-            given(walletStampCardRepository.findByCustomerWalletIdAndStoreId(walletId, storeId))
+            given(
+                            walletStampCardRepository.findByCustomerWalletIdAndStoreIdWithLock(
+                                    walletId, storeId))
                     .willReturn(Optional.of(walletStampCard));
             given(stampEventRepository.save(any(StampEvent.class)))
                     .willAnswer(i -> i.getArgument(0));
@@ -182,7 +207,7 @@ class OwnerMigrationServiceTest {
 
             // when
             MigrationApproveResponse response =
-                    ownerMigrationService.approve(storeId, migrationId, request);
+                    ownerMigrationService.approve(storeId, migrationId, request, OWNER_ID);
 
             // then
             assertThat(response.id()).isEqualTo(migrationId);
@@ -203,20 +228,28 @@ class OwnerMigrationServiceTest {
 
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
             StampCard activeCard = createActiveStampCard(10L, storeId);
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
             given(
                             stampCardRepository.findFirstByStoreIdAndStatusOrderByCreatedAtDesc(
                                     storeId, StampCardStatus.ACTIVE))
                     .willReturn(Optional.of(activeCard));
-            given(walletStampCardRepository.findByCustomerWalletIdAndStoreId(walletId, storeId))
+            given(
+                            walletStampCardRepository.findByCustomerWalletIdAndStoreIdWithLock(
+                                    walletId, storeId))
                     .willReturn(Optional.empty());
 
             MigrationApproveRequest request = new MigrationApproveRequest(3);
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.approve(storeId, migrationId, request))
+            assertThatThrownBy(
+                            () ->
+                                    ownerMigrationService.approve(
+                                            storeId, migrationId, request, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -234,14 +267,20 @@ class OwnerMigrationServiceTest {
 
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
             migration.approve(5); // 이미 승인됨
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
 
             MigrationApproveRequest request = new MigrationApproveRequest(3);
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.approve(storeId, migrationId, request))
+            assertThatThrownBy(
+                            () ->
+                                    ownerMigrationService.approve(
+                                            storeId, migrationId, request, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -258,7 +297,10 @@ class OwnerMigrationServiceTest {
             Long walletId = 100L;
 
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
             given(
@@ -269,7 +311,10 @@ class OwnerMigrationServiceTest {
             MigrationApproveRequest request = new MigrationApproveRequest(3);
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.approve(storeId, migrationId, request))
+            assertThatThrownBy(
+                            () ->
+                                    ownerMigrationService.approve(
+                                            storeId, migrationId, request, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -283,14 +328,20 @@ class OwnerMigrationServiceTest {
             // given
             Long storeId = 1L;
             Long migrationId = 999L;
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.empty());
 
             MigrationApproveRequest request = new MigrationApproveRequest(3);
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.approve(storeId, migrationId, request))
+            assertThatThrownBy(
+                            () ->
+                                    ownerMigrationService.approve(
+                                            storeId, migrationId, request, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -313,7 +364,10 @@ class OwnerMigrationServiceTest {
             String rejectReason = "사진이 불명확합니다.";
 
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
 
@@ -321,7 +375,7 @@ class OwnerMigrationServiceTest {
 
             // when
             MigrationRejectResponse response =
-                    ownerMigrationService.reject(storeId, migrationId, request);
+                    ownerMigrationService.reject(storeId, migrationId, request, OWNER_ID);
 
             // then
             assertThat(response.id()).isEqualTo(migrationId);
@@ -340,14 +394,20 @@ class OwnerMigrationServiceTest {
 
             StampMigrationRequest migration = createMigration(migrationId, walletId, storeId);
             migration.reject("이전 반려 사유");
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.of(migration));
 
             MigrationRejectRequest request = new MigrationRejectRequest("새 반려 사유");
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.reject(storeId, migrationId, request))
+            assertThatThrownBy(
+                            () ->
+                                    ownerMigrationService.reject(
+                                            storeId, migrationId, request, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -361,14 +421,20 @@ class OwnerMigrationServiceTest {
             // given
             Long storeId = 1L;
             Long migrationId = 999L;
+            Store store = createStore(storeId, OWNER_ID);
 
+            given(storeRepository.findByIdAndOwnerAccountId(storeId, OWNER_ID))
+                    .willReturn(Optional.of(store));
             given(migrationRepository.findByIdAndStoreId(migrationId, storeId))
                     .willReturn(Optional.empty());
 
             MigrationRejectRequest request = new MigrationRejectRequest("반려 사유");
 
             // when & then
-            assertThatThrownBy(() -> ownerMigrationService.reject(storeId, migrationId, request))
+            assertThatThrownBy(
+                            () ->
+                                    ownerMigrationService.reject(
+                                            storeId, migrationId, request, OWNER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(
                             ex ->
@@ -417,6 +483,13 @@ class OwnerMigrationServiceTest {
                         .build();
         setId(wsc, id);
         return wsc;
+    }
+
+    private Store createStore(Long id, Long ownerAccountId) {
+        Store store =
+                new Store("테스트 매장", "서울시 강남구", "02-1234-5678", StoreStatus.ACTIVE, ownerAccountId);
+        setId(store, id);
+        return store;
     }
 
     private void setId(Object entity, Long id) {


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #68 

## 📌 작업 내용 요약
- 마이그레이션 API에 매장 소유권 검증 로직 추가 (validateStoreOwnership)
- 리딤 세션 생성 시 OTP step-up 인증 필수화 (STEPUP_REQUIRED 에러 코드)
- WalletStampCard 조회 시 비관적 락 적용으로 동시성 제어
- 목록 조회 시 이미지 데이터 제외 (성능/보안)