### PR TITLE
feat: Store CLOSED 기능 제한, 리딤 보조 API 추가

### DIFF
--- a/backend/src/main/java/com/project/kkookk/issuance/service/CustomerIssuanceService.java
+++ b/backend/src/main/java/com/project/kkookk/issuance/service/CustomerIssuanceService.java
@@ -10,6 +10,8 @@ import com.project.kkookk.issuance.domain.IssuanceRequestStatus;
 import com.project.kkookk.issuance.repository.IssuanceRequestRepository;
 import com.project.kkookk.issuance.service.exception.IssuanceRequestAlreadyPendingException;
 import com.project.kkookk.issuance.service.exception.IssuanceRequestNotFoundException;
+import com.project.kkookk.store.domain.Store;
+import com.project.kkookk.store.domain.StoreStatus;
 import com.project.kkookk.store.repository.StoreRepository;
 import com.project.kkookk.wallet.domain.WalletStampCard;
 import com.project.kkookk.wallet.repository.WalletStampCardRepository;
@@ -42,9 +44,14 @@ public class CustomerIssuanceService {
     @Transactional
     public IssuanceRequestResult createIssuanceRequest(
             Long walletId, CreateIssuanceRequest request) {
-        // 1. 매장 존재 확인
-        if (!storeRepository.existsById(request.storeId())) {
-            throw new BusinessException(ErrorCode.STORE_NOT_FOUND);
+        // 1. 매장 조회 및 상태 확인
+        Store store =
+                storeRepository
+                        .findById(request.storeId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+        if (store.getStatus() != StoreStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.STORE_INACTIVE);
         }
 
         // 2. 지갑 스탬프카드 조회

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/TerminalRedeemApi.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/TerminalRedeemApi.java
@@ -1,0 +1,55 @@
+package com.project.kkookk.redeem.controller;
+
+import com.project.kkookk.global.exception.ErrorResponse;
+import com.project.kkookk.global.security.TerminalPrincipal;
+import com.project.kkookk.redeem.controller.dto.PendingRedeemSessionListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Terminal Redeem", description = "매장 단말 리딤 확인 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface TerminalRedeemApi {
+
+    @Operation(
+            summary = "대기 중인 리딤 세션 목록 조회",
+            description =
+                    "매장의 PENDING 상태 리딤 세션 목록을 조회합니다. "
+                            + "고객이 리딤을 시작하면 이 목록에 표시되며, "
+                            + "매장에서 고객의 리딤 요청을 확인할 수 있습니다. "
+                            + "만료된 세션은 자동으로 제외됩니다.")
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                schema =
+                                        @Schema(
+                                                implementation =
+                                                        PendingRedeemSessionListResponse.class))),
+        @ApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "해당 매장 접근 권한 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+                responseCode = "404",
+                description = "매장 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PendingRedeemSessionListResponse> getPendingRedeemSessions(
+            @Parameter(description = "매장 ID", example = "1") @PathVariable Long storeId,
+            @Parameter(hidden = true) @AuthenticationPrincipal TerminalPrincipal principal);
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/TerminalRedeemController.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/TerminalRedeemController.java
@@ -1,0 +1,31 @@
+package com.project.kkookk.redeem.controller;
+
+import com.project.kkookk.global.security.TerminalPrincipal;
+import com.project.kkookk.redeem.controller.dto.PendingRedeemSessionListResponse;
+import com.project.kkookk.redeem.service.TerminalRedeemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/terminal/{storeId}/redeem-sessions")
+public class TerminalRedeemController implements TerminalRedeemApi {
+
+    private final TerminalRedeemService terminalRedeemService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<PendingRedeemSessionListResponse> getPendingRedeemSessions(
+            @PathVariable Long storeId, @AuthenticationPrincipal TerminalPrincipal principal) {
+
+        PendingRedeemSessionListResponse response =
+                terminalRedeemService.getPendingRedeemSessions(storeId, principal.getOwnerId());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/dto/PendingRedeemSessionItem.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/dto/PendingRedeemSessionItem.java
@@ -1,0 +1,12 @@
+package com.project.kkookk.redeem.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "대기 중인 리딤 세션 항목")
+public record PendingRedeemSessionItem(
+        @Schema(description = "리딤 세션 ID", example = "1") Long sessionId,
+        @Schema(description = "고객 닉네임", example = "커피러버") String customerNickname,
+        @Schema(description = "리워드명", example = "아메리카노 1잔") String rewardName,
+        @Schema(description = "남은 시간 (초)", example = "45") long remainingSeconds,
+        @Schema(description = "세션 생성 시간") LocalDateTime createdAt) {}

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/dto/PendingRedeemSessionListResponse.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/dto/PendingRedeemSessionListResponse.java
@@ -1,0 +1,14 @@
+package com.project.kkookk.redeem.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "대기 중인 리딤 세션 목록 응답")
+public record PendingRedeemSessionListResponse(
+        @Schema(description = "대기 중인 리딤 세션 목록") List<PendingRedeemSessionItem> sessions,
+        @Schema(description = "총 개수", example = "3") int totalCount) {
+
+    public static PendingRedeemSessionListResponse of(List<PendingRedeemSessionItem> sessions) {
+        return new PendingRedeemSessionListResponse(sessions, sessions.size());
+    }
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/repository/RedeemSessionRepository.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/repository/RedeemSessionRepository.java
@@ -2,9 +2,23 @@ package com.project.kkookk.redeem.repository;
 
 import com.project.kkookk.redeem.domain.RedeemSession;
 import com.project.kkookk.redeem.domain.RedeemSessionStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RedeemSessionRepository extends JpaRepository<RedeemSession, Long> {
 
     boolean existsByWalletRewardIdAndStatus(Long walletRewardId, RedeemSessionStatus status);
+
+    @Query(
+            """
+            SELECT rs FROM RedeemSession rs
+            JOIN WalletReward wr ON rs.walletRewardId = wr.id
+            WHERE wr.storeId = :storeId
+            AND rs.status = :status
+            ORDER BY rs.createdAt ASC
+            """)
+    List<RedeemSession> findByStoreIdAndStatus(
+            @Param("storeId") Long storeId, @Param("status") RedeemSessionStatus status);
 }

--- a/backend/src/main/java/com/project/kkookk/redeem/service/CustomerRedeemService.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/service/CustomerRedeemService.java
@@ -11,6 +11,9 @@ import com.project.kkookk.redeem.domain.RedeemSession;
 import com.project.kkookk.redeem.domain.RedeemSessionStatus;
 import com.project.kkookk.redeem.repository.RedeemEventRepository;
 import com.project.kkookk.redeem.repository.RedeemSessionRepository;
+import com.project.kkookk.store.domain.Store;
+import com.project.kkookk.store.domain.StoreStatus;
+import com.project.kkookk.store.repository.StoreRepository;
 import com.project.kkookk.wallet.domain.WalletReward;
 import com.project.kkookk.wallet.repository.WalletRewardRepository;
 import java.time.LocalDateTime;
@@ -28,6 +31,7 @@ public class CustomerRedeemService {
     private final RedeemSessionRepository redeemSessionRepository;
     private final RedeemEventRepository redeemEventRepository;
     private final WalletRewardRepository walletRewardRepository;
+    private final StoreRepository storeRepository;
 
     @Transactional
     public RedeemSessionResponse createRedeemSession(
@@ -38,12 +42,22 @@ public class CustomerRedeemService {
                         .findByIdAndWalletId(request.walletRewardId(), walletId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.REWARD_NOT_FOUND));
 
-        // 2. AVAILABLE 상태 검증
+        // 2. 매장 상태 확인
+        Store store =
+                storeRepository
+                        .findById(reward.getStoreId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+        if (store.getStatus() != StoreStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.STORE_INACTIVE);
+        }
+
+        // 3. AVAILABLE 상태 검증
         if (!reward.isAvailable()) {
             throw new BusinessException(ErrorCode.REWARD_NOT_AVAILABLE);
         }
 
-        // 3. 중복 PENDING 세션 검증
+        // 4. 중복 PENDING 세션 검증
         boolean hasPendingSession =
                 redeemSessionRepository.existsByWalletRewardIdAndStatus(
                         request.walletRewardId(), RedeemSessionStatus.PENDING);
@@ -51,10 +65,10 @@ public class CustomerRedeemService {
             throw new BusinessException(ErrorCode.REDEEM_SESSION_ALREADY_EXISTS);
         }
 
-        // 4. WalletReward 상태 변경 (AVAILABLE → REDEEMING)
+        // 5. WalletReward 상태 변경 (AVAILABLE → REDEEMING)
         reward.startRedeeming();
 
-        // 5. RedeemSession 생성
+        // 6. RedeemSession 생성
         RedeemSession session =
                 RedeemSession.builder()
                         .walletRewardId(request.walletRewardId())

--- a/backend/src/main/java/com/project/kkookk/redeem/service/TerminalRedeemService.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/service/TerminalRedeemService.java
@@ -1,0 +1,93 @@
+package com.project.kkookk.redeem.service;
+
+import com.project.kkookk.global.exception.BusinessException;
+import com.project.kkookk.global.exception.ErrorCode;
+import com.project.kkookk.redeem.controller.dto.PendingRedeemSessionItem;
+import com.project.kkookk.redeem.controller.dto.PendingRedeemSessionListResponse;
+import com.project.kkookk.redeem.domain.RedeemSession;
+import com.project.kkookk.redeem.domain.RedeemSessionStatus;
+import com.project.kkookk.redeem.repository.RedeemSessionRepository;
+import com.project.kkookk.stampcard.domain.StampCard;
+import com.project.kkookk.stampcard.repository.StampCardRepository;
+import com.project.kkookk.store.domain.Store;
+import com.project.kkookk.store.repository.StoreRepository;
+import com.project.kkookk.wallet.domain.CustomerWallet;
+import com.project.kkookk.wallet.domain.WalletReward;
+import com.project.kkookk.wallet.repository.CustomerWalletRepository;
+import com.project.kkookk.wallet.repository.WalletRewardRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TerminalRedeemService {
+
+    private final RedeemSessionRepository redeemSessionRepository;
+    private final WalletRewardRepository walletRewardRepository;
+    private final CustomerWalletRepository customerWalletRepository;
+    private final StampCardRepository stampCardRepository;
+    private final StoreRepository storeRepository;
+
+    public PendingRedeemSessionListResponse getPendingRedeemSessions(Long storeId, Long ownerId) {
+        // 1. 매장 존재 및 소유권 검증
+        Store store =
+                storeRepository
+                        .findById(storeId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+        if (!store.getOwnerAccountId().equals(ownerId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // 2. PENDING 상태 리딤 세션 조회
+        List<RedeemSession> pendingSessions =
+                redeemSessionRepository.findByStoreIdAndStatus(
+                        storeId, RedeemSessionStatus.PENDING);
+
+        // 3. 만료되지 않은 세션만 필터링하고 DTO로 변환
+        LocalDateTime now = LocalDateTime.now();
+        List<PendingRedeemSessionItem> items = new ArrayList<>();
+
+        for (RedeemSession session : pendingSessions) {
+            // 만료된 세션 스킵
+            if (now.isAfter(session.getExpiresAt())) {
+                continue;
+            }
+
+            // 관련 정보 조회
+            WalletReward reward =
+                    walletRewardRepository.findById(session.getWalletRewardId()).orElse(null);
+            if (reward == null) {
+                continue;
+            }
+
+            CustomerWallet wallet =
+                    customerWalletRepository.findById(reward.getWalletId()).orElse(null);
+            if (wallet == null) {
+                continue;
+            }
+
+            StampCard stampCard =
+                    stampCardRepository.findById(reward.getStampCardId()).orElse(null);
+
+            String rewardName = stampCard != null ? stampCard.getRewardName() : "리워드";
+            long remainingSeconds = Duration.between(now, session.getExpiresAt()).getSeconds();
+
+            items.add(
+                    new PendingRedeemSessionItem(
+                            session.getId(),
+                            wallet.getNickname(),
+                            rewardName,
+                            Math.max(0, remainingSeconds),
+                            session.getCreatedAt()));
+        }
+
+        return PendingRedeemSessionListResponse.of(items);
+    }
+}

--- a/backend/src/test/java/com/project/kkookk/issuance/service/CustomerIssuanceServiceTest.java
+++ b/backend/src/test/java/com/project/kkookk/issuance/service/CustomerIssuanceServiceTest.java
@@ -17,6 +17,8 @@ import com.project.kkookk.issuance.domain.IssuanceRequestStatus;
 import com.project.kkookk.issuance.repository.IssuanceRequestRepository;
 import com.project.kkookk.issuance.service.exception.IssuanceRequestAlreadyPendingException;
 import com.project.kkookk.issuance.service.exception.IssuanceRequestNotFoundException;
+import com.project.kkookk.store.domain.Store;
+import com.project.kkookk.store.domain.StoreStatus;
 import com.project.kkookk.store.repository.StoreRepository;
 import com.project.kkookk.wallet.domain.WalletStampCard;
 import com.project.kkookk.wallet.repository.WalletStampCardRepository;
@@ -62,8 +64,9 @@ class CustomerIssuanceServiceTest {
 
             WalletStampCard walletStampCard =
                     createWalletStampCard(walletStampCardId, walletId, storeId, 3);
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.of(walletStampCard));
             given(
@@ -112,8 +115,9 @@ class CustomerIssuanceServiceTest {
                     createWalletStampCard(walletStampCardId, walletId, storeId, 3);
             IssuanceRequest existingRequest =
                     createIssuanceRequest(1L, storeId, walletId, walletStampCardId);
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.of(walletStampCard));
             given(
@@ -140,7 +144,7 @@ class CustomerIssuanceServiceTest {
 
             CreateIssuanceRequest request = new CreateIssuanceRequest(storeId, 10L, "test-key");
 
-            given(storeRepository.existsById(storeId)).willReturn(false);
+            given(storeRepository.findById(storeId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(
@@ -153,6 +157,28 @@ class CustomerIssuanceServiceTest {
         }
 
         @Test
+        @DisplayName("적립 요청 생성 실패 - 매장 비활성 상태")
+        void createIssuanceRequest_Fail_StoreInactive() {
+            // given
+            Long walletId = 1L;
+            Long storeId = 1L;
+
+            CreateIssuanceRequest request = new CreateIssuanceRequest(storeId, 10L, "test-key");
+            Store inactiveStore = createStore(storeId, StoreStatus.INACTIVE);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(inactiveStore));
+
+            // when & then
+            assertThatThrownBy(
+                            () -> customerIssuanceService.createIssuanceRequest(walletId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(
+                            e ->
+                                    assertThat(((BusinessException) e).getErrorCode())
+                                            .isEqualTo(ErrorCode.STORE_INACTIVE));
+        }
+
+        @Test
         @DisplayName("적립 요청 생성 실패 - 지갑 스탬프카드 없음")
         void createIssuanceRequest_Fail_WalletStampCardNotFound() {
             // given
@@ -162,8 +188,9 @@ class CustomerIssuanceServiceTest {
 
             CreateIssuanceRequest request =
                     new CreateIssuanceRequest(storeId, walletStampCardId, "test-key");
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.empty());
 
@@ -187,8 +214,9 @@ class CustomerIssuanceServiceTest {
 
             WalletStampCard walletStampCard =
                     createWalletStampCard(walletStampCardId, otherWalletId, storeId, 3);
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.of(walletStampCard));
 
@@ -215,8 +243,9 @@ class CustomerIssuanceServiceTest {
 
             WalletStampCard walletStampCard =
                     createWalletStampCard(walletStampCardId, walletId, storeId, 3);
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.of(walletStampCard));
             given(issuanceRequestRepository.findByWalletIdAndIdempotencyKey(walletId, "new-key"))
@@ -245,8 +274,9 @@ class CustomerIssuanceServiceTest {
 
             WalletStampCard walletStampCard =
                     createWalletStampCard(walletStampCardId, walletId, storeId, 3);
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.of(walletStampCard));
             given(issuanceRequestRepository.findByWalletIdAndIdempotencyKey(walletId, "test-key"))
@@ -280,8 +310,9 @@ class CustomerIssuanceServiceTest {
                     createWalletStampCard(walletStampCardId, walletId, storeId, 3);
             IssuanceRequest expiredRequest =
                     createExpiredIssuanceRequest(1L, storeId, walletId, walletStampCardId);
+            Store store = createStore(storeId, StoreStatus.ACTIVE);
 
-            given(storeRepository.existsById(storeId)).willReturn(true);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
             given(walletStampCardRepository.findById(walletStampCardId))
                     .willReturn(Optional.of(walletStampCard));
             given(
@@ -466,5 +497,11 @@ class CustomerIssuanceServiceTest {
         ReflectionTestUtils.setField(request, "id", id);
         ReflectionTestUtils.setField(request, "createdAt", LocalDateTime.now().minusSeconds(180));
         return request;
+    }
+
+    private Store createStore(Long id, StoreStatus status) {
+        Store store = new Store("테스트 매장", "서울시 강남구", "02-1234-5678", status, 1L);
+        ReflectionTestUtils.setField(store, "id", id);
+        return store;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #72 

## 📌 작업 내용 요약
- CustomerIssuanceService.java - Store 조회 및 ACTIVE 상태 검증 추가
- CustomerRedeemService.java - StoreRepository 의존성 추가 및 Store 상태 체크 추가
- 테스트 코드
  - CustomerIssuanceServiceTest.java:
    - storeRepository.existsById() → storeRepository.findById() mock 변경 (8개 테스트)
    - createStore() 헬퍼 메서드 추가
    - createIssuanceRequest_Fail_StoreInactive() 테스트 케이스 추가

- INACTIVE 상태 매장에서 적립 요청 시 → ErrorCode.STORE_INACTIVE (403)
- INACTIVE 상태 매장에서 리딤 세션 생성 시 → ErrorCode.STORE_INACTIVE (403)
- 리딤 세션 항목조회 사장님 터미널 확인용 API