### PR TITLE
feat: 고객 리워드 보관함 및 오너 리딤 이력 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/project/kkookk/redeem/controller/owner/OwnerRedeemEventApi.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/owner/OwnerRedeemEventApi.java
@@ -1,0 +1,68 @@
+package com.project.kkookk.redeem.controller.owner;
+
+import com.project.kkookk.global.dto.PageResponse;
+import com.project.kkookk.global.exception.ErrorResponse;
+import com.project.kkookk.global.security.OwnerPrincipal;
+import com.project.kkookk.redeem.controller.owner.dto.RedeemEventResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Owner Redeem Event", description = "사장님 리딤 이벤트 조회 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface OwnerRedeemEventApi {
+
+    @Operation(
+            summary = "리딤 사용 완료 내역 조회",
+            description = "해당 매장의 리딤 사용 완료(COMPLETED + SUCCESS) 내역을 페이징 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                schema =
+                                        @Schema(
+                                                description = "페이지 응답",
+                                                example =
+                                                        """
+                        {
+                            "content": [],
+                            "pageNumber": 0,
+                            "pageSize": 20,
+                            "totalElements": 0,
+                            "totalPages": 0,
+                            "isLast": true
+                        }
+                        """),
+                                array =
+                                        @ArraySchema(
+                                                schema =
+                                                        @Schema(
+                                                                implementation =
+                                                                        RedeemEventResponse
+                                                                                .class)))),
+        @ApiResponse(
+                responseCode = "404",
+                description = "매장을 찾을 수 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PageResponse<RedeemEventResponse>> getRedeemEvents(
+            @Parameter(description = "매장 ID", required = true) @PathVariable Long storeId,
+            @Parameter(description = "페이지 번호 (0-based)", example = "0")
+                    @RequestParam(defaultValue = "0")
+                    int page,
+            @Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20")
+                    int size,
+            @Parameter(hidden = true) @AuthenticationPrincipal OwnerPrincipal principal);
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/owner/OwnerRedeemEventController.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/owner/OwnerRedeemEventController.java
@@ -1,0 +1,38 @@
+package com.project.kkookk.redeem.controller.owner;
+
+import com.project.kkookk.global.dto.PageResponse;
+import com.project.kkookk.global.security.OwnerPrincipal;
+import com.project.kkookk.redeem.controller.owner.dto.RedeemEventResponse;
+import com.project.kkookk.redeem.service.OwnerRedeemEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner/stores/{storeId}/redeem-events")
+public class OwnerRedeemEventController implements OwnerRedeemEventApi {
+
+    private final OwnerRedeemEventService ownerRedeemEventService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<PageResponse<RedeemEventResponse>> getRedeemEvents(
+            @PathVariable Long storeId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal OwnerPrincipal principal) {
+
+        Page<RedeemEventResponse> events =
+                ownerRedeemEventService.getCompletedRedeemEvents(
+                        principal.getOwnerId(), storeId, page, size);
+
+        return ResponseEntity.ok(PageResponse.from(events));
+    }
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/controller/owner/dto/RedeemEventResponse.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/controller/owner/dto/RedeemEventResponse.java
@@ -1,0 +1,31 @@
+package com.project.kkookk.redeem.controller.owner.dto;
+
+import com.project.kkookk.redeem.domain.RedeemEventResult;
+import com.project.kkookk.redeem.domain.RedeemEventType;
+import com.project.kkookk.redeem.repository.RedeemEventProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "리딤 이벤트 응답")
+public record RedeemEventResponse(
+        @Schema(description = "이벤트 ID", example = "1") Long id,
+        @Schema(description = "리딤 세션 ID", example = "100") Long redeemSessionId,
+        @Schema(description = "고객 닉네임", example = "커피러버") String customerNickname,
+        @Schema(description = "리워드 이름", example = "아메리카노 1잔") String rewardName,
+        @Schema(description = "스탬프카드 제목", example = "커피전문점 스탬프카드") String stampCardTitle,
+        @Schema(description = "이벤트 타입", example = "COMPLETED") RedeemEventType type,
+        @Schema(description = "이벤트 결과", example = "SUCCESS") RedeemEventResult result,
+        @Schema(description = "발생 일시", example = "2026-02-04T14:30:00") LocalDateTime occurredAt) {
+
+    public static RedeemEventResponse from(RedeemEventProjection projection) {
+        return new RedeemEventResponse(
+                projection.getId(),
+                projection.getRedeemSessionId(),
+                projection.getCustomerNickname(),
+                projection.getRewardName(),
+                projection.getStampCardTitle(),
+                projection.getType(),
+                projection.getResult(),
+                projection.getOccurredAt());
+    }
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/repository/RedeemEventProjection.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/repository/RedeemEventProjection.java
@@ -1,0 +1,24 @@
+package com.project.kkookk.redeem.repository;
+
+import com.project.kkookk.redeem.domain.RedeemEventResult;
+import com.project.kkookk.redeem.domain.RedeemEventType;
+import java.time.LocalDateTime;
+
+public interface RedeemEventProjection {
+
+    Long getId();
+
+    Long getRedeemSessionId();
+
+    String getCustomerNickname();
+
+    String getRewardName();
+
+    String getStampCardTitle();
+
+    RedeemEventType getType();
+
+    RedeemEventResult getResult();
+
+    LocalDateTime getOccurredAt();
+}

--- a/backend/src/main/java/com/project/kkookk/redeem/repository/RedeemEventRepository.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/repository/RedeemEventRepository.java
@@ -25,4 +25,28 @@ public interface RedeemEventRepository extends JpaRepository<RedeemEvent, Long> 
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate,
             @Param("result") RedeemEventResult result);
+
+    @Query(
+            """
+            SELECT
+                e.id as id,
+                e.redeemSessionId as redeemSessionId,
+                cw.nickname as customerNickname,
+                sc.rewardName as rewardName,
+                sc.title as stampCardTitle,
+                e.type as type,
+                e.result as result,
+                e.occurredAt as occurredAt
+            FROM RedeemEvent e
+            JOIN RedeemSession rs ON e.redeemSessionId = rs.id
+            JOIN WalletReward wr ON rs.walletRewardId = wr.id
+            JOIN CustomerWallet cw ON e.walletId = cw.id
+            JOIN StampCard sc ON wr.stampCardId = sc.id
+            WHERE e.storeId = :storeId
+            AND e.type = com.project.kkookk.redeem.domain.RedeemEventType.COMPLETED
+            AND e.result = com.project.kkookk.redeem.domain.RedeemEventResult.SUCCESS
+            ORDER BY e.occurredAt DESC
+            """)
+    Page<RedeemEventProjection> findCompletedByStoreId(
+            @Param("storeId") Long storeId, Pageable pageable);
 }

--- a/backend/src/main/java/com/project/kkookk/redeem/service/OwnerRedeemEventService.java
+++ b/backend/src/main/java/com/project/kkookk/redeem/service/OwnerRedeemEventService.java
@@ -1,0 +1,40 @@
+package com.project.kkookk.redeem.service;
+
+import com.project.kkookk.global.exception.BusinessException;
+import com.project.kkookk.global.exception.ErrorCode;
+import com.project.kkookk.redeem.controller.owner.dto.RedeemEventResponse;
+import com.project.kkookk.redeem.repository.RedeemEventProjection;
+import com.project.kkookk.redeem.repository.RedeemEventRepository;
+import com.project.kkookk.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OwnerRedeemEventService {
+
+    private final RedeemEventRepository redeemEventRepository;
+    private final StoreRepository storeRepository;
+
+    public Page<RedeemEventResponse> getCompletedRedeemEvents(
+            Long ownerId, Long storeId, int page, int size) {
+        validateStoreOwnership(ownerId, storeId);
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RedeemEventProjection> events =
+                redeemEventRepository.findCompletedByStoreId(storeId, pageable);
+
+        return events.map(RedeemEventResponse::from);
+    }
+
+    private void validateStoreOwnership(Long ownerId, Long storeId) {
+        storeRepository
+                .findByIdAndOwnerAccountId(storeId, ownerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/project/kkookk/wallet/controller/customer/CustomerWalletApi.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/controller/customer/CustomerWalletApi.java
@@ -2,8 +2,10 @@ package com.project.kkookk.wallet.controller.customer;
 
 import com.project.kkookk.global.security.CustomerPrincipal;
 import com.project.kkookk.wallet.domain.StampCardSortType;
+import com.project.kkookk.wallet.domain.WalletRewardStatus;
 import com.project.kkookk.wallet.dto.response.RedeemEventHistoryResponse;
 import com.project.kkookk.wallet.dto.response.StampEventHistoryResponse;
+import com.project.kkookk.wallet.dto.response.WalletRewardListResponse;
 import com.project.kkookk.wallet.dto.response.WalletStampCardListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -95,6 +97,33 @@ public interface CustomerWalletApi {
     @GetMapping("/api/customer/wallet/redeem-history")
     ResponseEntity<RedeemEventHistoryResponse> getRedeemHistory(
             @AuthenticationPrincipal CustomerPrincipal principal,
+            @Parameter(description = "페이지 번호 (0-based)") @RequestParam(defaultValue = "0") @Min(0)
+                    int page,
+            @Parameter(description = "페이지 크기 (1~100)")
+                    @RequestParam(defaultValue = "20")
+                    @Min(1)
+                    @Max(100)
+                    int size);
+
+    @Operation(
+            summary = "리워드 보관함 조회 (StepUp 토큰 필수)",
+            description =
+                    """
+            인증된 고객의 보유 리워드(쿠폰) 목록을 페이징하여 조회합니다.
+            상태별 필터링이 가능합니다. OTP 인증 후 발급된 StepUp 토큰이 필요합니다.
+            """)
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 페이징 파라미터"),
+        @ApiResponse(responseCode = "401", description = "인증 필요 (JWT 토큰 없음/만료)"),
+        @ApiResponse(responseCode = "403", description = "StepUp 인증 필요")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/api/customer/wallet/rewards")
+    ResponseEntity<WalletRewardListResponse> getRewards(
+            @AuthenticationPrincipal CustomerPrincipal principal,
+            @Parameter(description = "리워드 상태 필터 (미지정 시 전체 조회)") @RequestParam(required = false)
+                    WalletRewardStatus status,
             @Parameter(description = "페이지 번호 (0-based)") @RequestParam(defaultValue = "0") @Min(0)
                     int page,
             @Parameter(description = "페이지 크기 (1~100)")

--- a/backend/src/main/java/com/project/kkookk/wallet/controller/customer/CustomerWalletController.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/controller/customer/CustomerWalletController.java
@@ -4,8 +4,10 @@ import com.project.kkookk.global.exception.BusinessException;
 import com.project.kkookk.global.exception.ErrorCode;
 import com.project.kkookk.global.security.CustomerPrincipal;
 import com.project.kkookk.wallet.domain.StampCardSortType;
+import com.project.kkookk.wallet.domain.WalletRewardStatus;
 import com.project.kkookk.wallet.dto.response.RedeemEventHistoryResponse;
 import com.project.kkookk.wallet.dto.response.StampEventHistoryResponse;
+import com.project.kkookk.wallet.dto.response.WalletRewardListResponse;
 import com.project.kkookk.wallet.dto.response.WalletStampCardListResponse;
 import com.project.kkookk.wallet.service.CustomerWalletService;
 import jakarta.validation.constraints.Max;
@@ -79,6 +81,27 @@ public class CustomerWalletController implements CustomerWalletApi {
         Pageable pageable = PageRequest.of(page, size, Sort.by("occurredAt").descending());
         RedeemEventHistoryResponse response =
                 customerWalletService.getRedeemHistory(walletId, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<WalletRewardListResponse> getRewards(
+            CustomerPrincipal principal,
+            WalletRewardStatus status,
+            @Min(0) int page,
+            @Min(1) @Max(100) int size) {
+
+        // StepUp 인증 필수
+        if (!principal.isStepUp()) {
+            throw new BusinessException(ErrorCode.STEPUP_REQUIRED);
+        }
+
+        Long walletId = principal.getWalletId();
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("issuedAt").descending());
+        WalletRewardListResponse response =
+                customerWalletService.getRewards(walletId, status, pageable);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/project/kkookk/wallet/dto/response/WalletRewardItem.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/dto/response/WalletRewardItem.java
@@ -1,0 +1,16 @@
+package com.project.kkookk.wallet.dto.response;
+
+import com.project.kkookk.wallet.domain.WalletRewardStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "지갑 리워드 항목")
+public record WalletRewardItem(
+        @Schema(description = "리워드 ID", example = "1") Long id,
+        @Schema(description = "매장 정보") StoreInfo store,
+        @Schema(description = "리워드명", example = "아메리카노 1잔") String rewardName,
+        @Schema(description = "스탬프카드 제목", example = "꾹꾹 스탬프") String stampCardTitle,
+        @Schema(description = "리워드 상태") WalletRewardStatus status,
+        @Schema(description = "발급일시") LocalDateTime issuedAt,
+        @Schema(description = "만료일시") LocalDateTime expiresAt,
+        @Schema(description = "사용일시 (사용한 경우)") LocalDateTime redeemedAt) {}

--- a/backend/src/main/java/com/project/kkookk/wallet/dto/response/WalletRewardListResponse.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/dto/response/WalletRewardListResponse.java
@@ -1,0 +1,9 @@
+package com.project.kkookk.wallet.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "지갑 리워드 목록 응답")
+public record WalletRewardListResponse(
+        @Schema(description = "리워드 목록") List<WalletRewardItem> rewards,
+        @Schema(description = "페이지 정보") PageInfo pageInfo) {}

--- a/backend/src/main/java/com/project/kkookk/wallet/repository/WalletRewardRepository.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/repository/WalletRewardRepository.java
@@ -1,8 +1,11 @@
 package com.project.kkookk.wallet.repository;
 
 import com.project.kkookk.wallet.domain.WalletReward;
+import com.project.kkookk.wallet.domain.WalletRewardStatus;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +13,11 @@ import org.springframework.data.repository.query.Param;
 public interface WalletRewardRepository extends JpaRepository<WalletReward, Long> {
 
     Optional<WalletReward> findByIdAndWalletId(Long id, Long walletId);
+
+    Page<WalletReward> findByWalletIdOrderByIssuedAtDesc(Long walletId, Pageable pageable);
+
+    Page<WalletReward> findByWalletIdAndStatusOrderByIssuedAtDesc(
+            Long walletId, WalletRewardStatus status, Pageable pageable);
 
     @Query(
             """

--- a/backend/src/main/java/com/project/kkookk/wallet/service/CustomerWalletService.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/service/CustomerWalletService.java
@@ -13,6 +13,8 @@ import com.project.kkookk.store.domain.Store;
 import com.project.kkookk.store.repository.StoreRepository;
 import com.project.kkookk.wallet.domain.CustomerWallet;
 import com.project.kkookk.wallet.domain.StampCardSortType;
+import com.project.kkookk.wallet.domain.WalletReward;
+import com.project.kkookk.wallet.domain.WalletRewardStatus;
 import com.project.kkookk.wallet.domain.WalletStampCard;
 import com.project.kkookk.wallet.dto.WalletRegisterRequest;
 import com.project.kkookk.wallet.dto.WalletRegisterResponse;
@@ -21,9 +23,13 @@ import com.project.kkookk.wallet.dto.response.RedeemEventHistoryResponse;
 import com.project.kkookk.wallet.dto.response.RedeemEventSummary;
 import com.project.kkookk.wallet.dto.response.StampEventHistoryResponse;
 import com.project.kkookk.wallet.dto.response.StampEventSummary;
+import com.project.kkookk.wallet.dto.response.StoreInfo;
+import com.project.kkookk.wallet.dto.response.WalletRewardItem;
+import com.project.kkookk.wallet.dto.response.WalletRewardListResponse;
 import com.project.kkookk.wallet.dto.response.WalletStampCardListResponse;
 import com.project.kkookk.wallet.dto.response.WalletStampCardSummary;
 import com.project.kkookk.wallet.repository.CustomerWalletRepository;
+import com.project.kkookk.wallet.repository.WalletRewardRepository;
 import com.project.kkookk.wallet.repository.WalletStampCardRepository;
 import com.project.kkookk.wallet.service.exception.CustomerWalletBlockedException;
 import com.project.kkookk.wallet.service.exception.CustomerWalletNotFoundException;
@@ -49,6 +55,7 @@ public class CustomerWalletService {
 
     private final CustomerWalletRepository customerWalletRepository;
     private final WalletStampCardRepository walletStampCardRepository;
+    private final WalletRewardRepository walletRewardRepository;
     private final StampCardRepository stampCardRepository;
     private final StoreRepository storeRepository;
     private final StampEventRepository stampEventRepository;
@@ -211,6 +218,59 @@ public class CustomerWalletService {
                         .toList();
 
         return new RedeemEventHistoryResponse(events, PageInfo.from(eventPage));
+    }
+
+    public WalletRewardListResponse getRewards(
+            Long walletId, WalletRewardStatus status, Pageable pageable) {
+
+        // Step 1: WalletReward 페이징 조회 (상태 필터 선택적)
+        Page<WalletReward> rewardPage;
+        if (status != null) {
+            rewardPage =
+                    walletRewardRepository.findByWalletIdAndStatusOrderByIssuedAtDesc(
+                            walletId, status, pageable);
+        } else {
+            rewardPage =
+                    walletRewardRepository.findByWalletIdOrderByIssuedAtDesc(walletId, pageable);
+        }
+
+        // Step 2: Store, StampCard Batch 조회 (N+1 방지)
+        Set<Long> storeIds =
+                rewardPage.getContent().stream()
+                        .map(WalletReward::getStoreId)
+                        .collect(Collectors.toSet());
+        Set<Long> stampCardIds =
+                rewardPage.getContent().stream()
+                        .map(WalletReward::getStampCardId)
+                        .collect(Collectors.toSet());
+
+        Map<Long, Store> storeMap =
+                storeRepository.findAllById(storeIds).stream()
+                        .collect(Collectors.toMap(Store::getId, Function.identity()));
+        Map<Long, StampCard> stampCardMap =
+                stampCardRepository.findAllById(stampCardIds).stream()
+                        .collect(Collectors.toMap(StampCard::getId, Function.identity()));
+
+        // Step 3: Response 조립
+        List<WalletRewardItem> rewards =
+                rewardPage.getContent().stream()
+                        .map(
+                                reward -> {
+                                    Store store = storeMap.get(reward.getStoreId());
+                                    StampCard stampCard = stampCardMap.get(reward.getStampCardId());
+                                    return new WalletRewardItem(
+                                            reward.getId(),
+                                            new StoreInfo(store.getId(), store.getName()),
+                                            stampCard != null ? stampCard.getRewardName() : null,
+                                            stampCard != null ? stampCard.getTitle() : null,
+                                            reward.getStatus(),
+                                            reward.getIssuedAt(),
+                                            reward.getExpiresAt(),
+                                            reward.getRedeemedAt());
+                                })
+                        .toList();
+
+        return new WalletRewardListResponse(rewards, PageInfo.from(rewardPage));
     }
 
     private List<WalletStampCard> getWalletStampCardsSorted(

--- a/backend/src/test/java/com/project/kkookk/redeem/controller/owner/OwnerRedeemEventControllerTest.java
+++ b/backend/src/test/java/com/project/kkookk/redeem/controller/owner/OwnerRedeemEventControllerTest.java
@@ -1,0 +1,154 @@
+package com.project.kkookk.redeem.controller.owner;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.project.kkookk.global.exception.BusinessException;
+import com.project.kkookk.global.exception.ErrorCode;
+import com.project.kkookk.global.security.JwtAuthenticationFilter;
+import com.project.kkookk.owner.controller.config.TestSecurityConfig;
+import com.project.kkookk.owner.controller.config.WithMockOwner;
+import com.project.kkookk.redeem.controller.owner.dto.RedeemEventResponse;
+import com.project.kkookk.redeem.domain.RedeemEventResult;
+import com.project.kkookk.redeem.domain.RedeemEventType;
+import com.project.kkookk.redeem.service.OwnerRedeemEventService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest(
+        controllers = OwnerRedeemEventController.class,
+        excludeAutoConfiguration = {
+            org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        })
+@Import(TestSecurityConfig.class)
+@WithMockOwner(ownerId = 1L, email = "owner@example.com")
+class OwnerRedeemEventControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private OwnerRedeemEventService ownerRedeemEventService;
+
+    @MockitoBean private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Autowired private WebApplicationContext context;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    }
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long STORE_ID = 1L;
+
+    @Test
+    @DisplayName("리딤 이벤트 조회 성공 - 200 OK")
+    void getRedeemEvents_Success() throws Exception {
+        // given
+        RedeemEventResponse event =
+                new RedeemEventResponse(
+                        1L,
+                        100L,
+                        "커피러버",
+                        "아메리카노 1잔",
+                        "커피전문점 스탬프카드",
+                        RedeemEventType.COMPLETED,
+                        RedeemEventResult.SUCCESS,
+                        LocalDateTime.of(2026, 2, 4, 14, 30, 0));
+
+        Page<RedeemEventResponse> page = new PageImpl<>(List.of(event), PageRequest.of(0, 20), 1);
+
+        given(
+                        ownerRedeemEventService.getCompletedRedeemEvents(
+                                anyLong(), anyLong(), anyInt(), anyInt()))
+                .willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/api/owner/stores/{storeId}/redeem-events", STORE_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].redeemSessionId").value(100))
+                .andExpect(jsonPath("$.content[0].customerNickname").value("커피러버"))
+                .andExpect(jsonPath("$.content[0].rewardName").value("아메리카노 1잔"))
+                .andExpect(jsonPath("$.content[0].stampCardTitle").value("커피전문점 스탬프카드"))
+                .andExpect(jsonPath("$.content[0].type").value("COMPLETED"))
+                .andExpect(jsonPath("$.content[0].result").value("SUCCESS"))
+                .andExpect(jsonPath("$.pageNumber").value(0))
+                .andExpect(jsonPath("$.pageSize").value(20))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.isLast").value(true));
+    }
+
+    @Test
+    @DisplayName("리딤 이벤트 조회 - 빈 결과 - 200 OK")
+    void getRedeemEvents_EmptyResult() throws Exception {
+        // given
+        Page<RedeemEventResponse> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
+
+        given(
+                        ownerRedeemEventService.getCompletedRedeemEvents(
+                                anyLong(), anyLong(), anyInt(), anyInt()))
+                .willReturn(emptyPage);
+
+        // when & then
+        mockMvc.perform(get("/api/owner/stores/{storeId}/redeem-events", STORE_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content").isEmpty())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    @DisplayName("리딤 이벤트 조회 실패 - 매장 없음 - 404 Not Found")
+    void getRedeemEvents_StoreNotFound() throws Exception {
+        // given
+        given(
+                        ownerRedeemEventService.getCompletedRedeemEvents(
+                                anyLong(), anyLong(), anyInt(), anyInt()))
+                .willThrow(new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/owner/stores/{storeId}/redeem-events", STORE_ID))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("리딤 이벤트 조회 - 페이징 파라미터 적용")
+    void getRedeemEvents_WithPagination() throws Exception {
+        // given
+        Page<RedeemEventResponse> page = new PageImpl<>(List.of(), PageRequest.of(2, 10), 25);
+
+        given(ownerRedeemEventService.getCompletedRedeemEvents(OWNER_ID, STORE_ID, 2, 10))
+                .willReturn(page);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/owner/stores/{storeId}/redeem-events", STORE_ID)
+                                .param("page", "2")
+                                .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pageNumber").value(2))
+                .andExpect(jsonPath("$.pageSize").value(10))
+                .andExpect(jsonPath("$.totalElements").value(25))
+                .andExpect(jsonPath("$.totalPages").value(3));
+    }
+}


### PR DESCRIPTION
## Summary
- 고객 리워드 보관함 조회 API 추가 (`GET /api/customer/wallet/rewards`)
  - StepUp 토큰 인증 필수
  - 상태별 필터링 및 페이징 지원
- 오너용 리딤 이벤트 이력 조회 API 추가 (`GET /api/owner/stores/{storeId}/redeem-events`)
  - 성공한 완료 이벤트만 조회
  - 페이징 지원

## Changes
- `CustomerWalletApi`, `CustomerWalletController` - 리워드 보관함 조회 엔드포인트 추가
- `WalletRewardRepository` - 상태별 조회 메서드 추가
- `CustomerWalletService` - 리워드 조회 로직 구현
- `OwnerRedeemEventApi`, `OwnerRedeemEventController` - 오너 리딤 이력 조회 엔드포인트
- `OwnerRedeemEventService` - 리딤 이력 조회 서비스
- `RedeemEventRepository`, `RedeemEventProjection` - 리딤 이벤트 조회 쿼리 추가

## Test plan
- [x] OwnerRedeemEventControllerTest 추가
- [ ] 수동 테스트: Swagger UI에서 API 호출 확인

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)