### PR TITLE
WalletReward 저장을 JdbcClient batch insert로 전환

### DIFF
--- a/backend/src/main/java/com/project/kkookk/stamp/service/StampRewardService.java
+++ b/backend/src/main/java/com/project/kkookk/stamp/service/StampRewardService.java
@@ -3,7 +3,7 @@ package com.project.kkookk.stamp.service;
 import com.project.kkookk.stampcard.domain.StampCard;
 import com.project.kkookk.wallet.domain.WalletReward;
 import com.project.kkookk.wallet.domain.WalletStampCard;
-import com.project.kkookk.wallet.repository.WalletRewardRepository;
+import com.project.kkookk.wallet.repository.WalletRewardBatchRepository;
 import com.project.kkookk.wallet.repository.WalletStampCardRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class StampRewardService {
 
-    private final WalletRewardRepository walletRewardRepository;
+    private final WalletRewardBatchRepository walletRewardBatchRepository;
     private final WalletStampCardRepository walletStampCardRepository;
 
     /**
@@ -59,7 +59,7 @@ public class StampRewardService {
                 issuedRewards.add(reward);
             }
 
-            walletRewardRepository.saveAll(issuedRewards);
+            walletRewardBatchRepository.batchInsert(issuedRewards);
 
             // 기존 WalletStampCard 완료 처리
             walletStampCard.setStampCount(goalStampCount); // 목표 달성 상태로

--- a/backend/src/main/java/com/project/kkookk/wallet/repository/WalletRewardBatchRepository.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/repository/WalletRewardBatchRepository.java
@@ -1,0 +1,57 @@
+package com.project.kkookk.wallet.repository;
+
+import com.project.kkookk.wallet.domain.WalletReward;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WalletRewardBatchRepository {
+
+    private final JdbcClient jdbcClient;
+    private static final int BATCH_SIZE = 50;
+
+    private static final String INSERT_PREFIX =
+            "INSERT INTO wallet_reward "
+                    + "(wallet_id, stamp_card_id, store_id, status, "
+                    + "issued_at, expires_at, created_at, updated_at) VALUES ";
+
+    private static final String VALUE_PLACEHOLDER = "(?, ?, ?, ?, ?, ?, ?, ?)";
+
+    public void batchInsert(List<WalletReward> rewards) {
+        if (rewards.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i = 0; i < rewards.size(); i += BATCH_SIZE) {
+            List<WalletReward> batch = rewards.subList(i, Math.min(i + BATCH_SIZE, rewards.size()));
+
+            String sql =
+                    INSERT_PREFIX
+                            + batch.stream()
+                                    .map(r -> VALUE_PLACEHOLDER)
+                                    .collect(Collectors.joining(", "));
+
+            List<Object> params = new ArrayList<>(batch.size() * 8);
+            for (WalletReward reward : batch) {
+                params.add(reward.getWalletId());
+                params.add(reward.getStampCardId());
+                params.add(reward.getStoreId());
+                params.add(reward.getStatus().name());
+                params.add(reward.getIssuedAt());
+                params.add(reward.getExpiresAt());
+                params.add(now);
+                params.add(now);
+            }
+
+            jdbcClient.sql(sql).params(params).update();
+        }
+    }
+}

--- a/backend/src/test/java/com/project/kkookk/stamp/service/StampRewardServiceTest.java
+++ b/backend/src/test/java/com/project/kkookk/stamp/service/StampRewardServiceTest.java
@@ -12,7 +12,7 @@ import com.project.kkookk.stampcard.domain.StampCard;
 import com.project.kkookk.stampcard.domain.StampCardStatus;
 import com.project.kkookk.wallet.domain.WalletReward;
 import com.project.kkookk.wallet.domain.WalletStampCard;
-import com.project.kkookk.wallet.repository.WalletRewardRepository;
+import com.project.kkookk.wallet.repository.WalletRewardBatchRepository;
 import com.project.kkookk.wallet.repository.WalletStampCardRepository;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -31,7 +31,7 @@ class StampRewardServiceTest {
 
     @InjectMocks private StampRewardService stampRewardService;
 
-    @Mock private WalletRewardRepository walletRewardRepository;
+    @Mock private WalletRewardBatchRepository walletRewardBatchRepository;
     @Mock private WalletStampCardRepository walletStampCardRepository;
 
     @Captor private ArgumentCaptor<List<WalletReward>> rewardsCaptor;
@@ -56,7 +56,7 @@ class StampRewardServiceTest {
             assertThat(result.currentWalletStampCard()).isSameAs(walletStampCard);
             assertThat(walletStampCard.getStampCount()).isEqualTo(5); // 3 + 2 = 5
             assertThat(walletStampCard.isActive()).isTrue();
-            verify(walletRewardRepository, never()).saveAll(anyList());
+            verify(walletRewardBatchRepository, never()).batchInsert(anyList());
         }
 
         @Test
@@ -66,7 +66,6 @@ class StampRewardServiceTest {
             WalletStampCard walletStampCard = createWalletStampCard(1L, 100L, 1L, 10L, 8);
             StampCard stampCard = createStampCard(10L, 1L, 10, 30);
 
-            given(walletRewardRepository.saveAll(anyList())).willAnswer(i -> i.getArgument(0));
             given(walletStampCardRepository.save(any(WalletStampCard.class)))
                     .willAnswer(
                             i -> {
@@ -89,7 +88,7 @@ class StampRewardServiceTest {
             assertThat(result.currentWalletStampCard()).isNotSameAs(walletStampCard);
             assertThat(result.currentWalletStampCard().getStampCount()).isEqualTo(0);
             assertThat(result.currentWalletStampCard().isActive()).isTrue();
-            verify(walletRewardRepository).saveAll(rewardsCaptor.capture());
+            verify(walletRewardBatchRepository).batchInsert(rewardsCaptor.capture());
             assertThat(rewardsCaptor.getValue()).hasSize(1);
         }
 
@@ -100,7 +99,6 @@ class StampRewardServiceTest {
             WalletStampCard walletStampCard = createWalletStampCard(1L, 100L, 1L, 10L, 8);
             StampCard stampCard = createStampCard(10L, 1L, 10, 30);
 
-            given(walletRewardRepository.saveAll(anyList())).willAnswer(i -> i.getArgument(0));
             given(walletStampCardRepository.save(any(WalletStampCard.class)))
                     .willAnswer(
                             i -> {
@@ -129,7 +127,6 @@ class StampRewardServiceTest {
             WalletStampCard walletStampCard = createWalletStampCard(1L, 100L, 1L, 10L, 8);
             StampCard stampCard = createStampCard(10L, 1L, 10, 30);
 
-            given(walletRewardRepository.saveAll(anyList())).willAnswer(i -> i.getArgument(0));
             given(walletStampCardRepository.save(any(WalletStampCard.class)))
                     .willAnswer(
                             i -> {
@@ -149,7 +146,7 @@ class StampRewardServiceTest {
             assertThat(walletStampCard.isActive()).isFalse();
             // 새 카드에 초과분 이월 (8 + 25) % 10 = 3
             assertThat(result.currentWalletStampCard().getStampCount()).isEqualTo(3);
-            verify(walletRewardRepository).saveAll(rewardsCaptor.capture());
+            verify(walletRewardBatchRepository).batchInsert(rewardsCaptor.capture());
             assertThat(rewardsCaptor.getValue()).hasSize(3);
         }
 
@@ -160,7 +157,6 @@ class StampRewardServiceTest {
             WalletStampCard walletStampCard = createWalletStampCard(1L, 100L, 1L, 10L, 9);
             StampCard stampCard = createStampCard(10L, 1L, 10, 30);
 
-            given(walletRewardRepository.saveAll(anyList())).willAnswer(i -> i.getArgument(0));
             given(walletStampCardRepository.save(any(WalletStampCard.class)))
                     .willAnswer(
                             i -> {
@@ -187,7 +183,6 @@ class StampRewardServiceTest {
             WalletStampCard walletStampCard = createWalletStampCard(1L, 100L, 1L, 10L, 9);
             StampCard stampCard = createStampCard(10L, 1L, 10, null);
 
-            given(walletRewardRepository.saveAll(anyList())).willAnswer(i -> i.getArgument(0));
             given(walletStampCardRepository.save(any(WalletStampCard.class)))
                     .willAnswer(
                             i -> {
@@ -221,7 +216,7 @@ class StampRewardServiceTest {
             assertThat(result.currentWalletStampCard()).isSameAs(walletStampCard);
             assertThat(walletStampCard.getStampCount()).isEqualTo(5);
             assertThat(walletStampCard.isActive()).isTrue();
-            verify(walletRewardRepository, never()).saveAll(anyList());
+            verify(walletRewardBatchRepository, never()).batchInsert(anyList());
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈 Closes #85 

## 📌 작업 내용 요약
`WalletReward` 대량 저장 시 N번의 개별 INSERT가 발생하는 성능 병목을 **JdbcClient 기반 Multi-row INSERT**로 개선했습니다.

## 🚀 변경 사항
### 문제 상황 
`walletRewardRepository.saveAll(issuedRewards)` 호출 시, 리워드 개수만큼 **개별 INSERT**가 실행되고 있었습니다.

- 예: goalStampCount=10인 스탬프카드에 마이그레이션으로 30개 일괄 적립 → 리워드 3개 발급 → **INSERT 3회 실행**

### 근본 원인: IDENTITY 전략과 Batch Insert의 비호환

엔티티의 ID 생성 전략이 `GenerationType.IDENTITY`로 설정되어 있습니다:

```java
@Id
@GeneratedValue(strategy = GenerationType.IDENTITY)
private Long id;
```

Hibernate는 `persist()` 호출 시 영속성 컨텍스트(`Map<ID, Entity>`)에 엔티티를 저장하기 위해 **즉시 ID가 필요**합니다.
그런데 IDENTITY 전략은 **실제 INSERT를 실행해야만** DB가 ID를 생성하므로, "모아서 한꺼번에 보내기"가 원천적으로 불가능합니다.

→ **Hibernate는 IDENTITY 전략에서 배치 인서트를 자동 비활성화합니다.**

### 해결 방안 비교 (ADR)

| 방안 | 설명 | 채택 여부 | 사유 |
|------|------|-----------|------|
| **TABLE 전략** | 별도 테이블에서 ID 채번 | ❌ | 락 경합으로 성능 저하, MySQL에 부적합 |
| **UUID 등 앱 생성 ID** | 애플리케이션에서 직접 ID 생성 | ❌ | 기존 11개 엔티티 모두 IDENTITY 사용 중 → 일관성 파괴 |
| **JDBC 직접 사용** | JPA 우회하여 Multi-row INSERT | ✅ | 변경 범위 최소화, 기존 구조 유지 |

### 구현: JdbcClient + Multi-row INSERT

- **`WalletRewardBatchRepository`** 신규 생성
  - `JdbcClient`를 사용한 Multi-row INSERT 구현
  - 50개 단위 파티셔닝(`BATCH_SIZE = 50`)으로 MySQL 패킷 크기 제한 방지
  - JPA 감사(`@CreatedDate`, `@LastModifiedDate`) 미작동 → SQL에서 직접 `created_at`, `updated_at` 처리
- **`StampRewardService`** 호출부 변경
  - `walletRewardRepository.saveAll()` → `walletRewardBatchRepository.batchInsert()`
- **`StampRewardServiceTest`** 테스트 수정
  - Mock 대상을 `WalletRewardBatchRepository`로 교체
  - `saveAll()` → `batchInsert()`로 verify 변경
  - 불필요한 `given(saveAll)` stubbing 제거 (void 메서드이므로 불필요)

### 성능 개선 결과

| 항목 | Before | After |
|------|--------|-------|
| **방식** | N번 개별 INSERT | 50개씩 Multi-row INSERT |
| **리워드 3개** | INSERT 3회 | INSERT 1회 |
| **리워드 120개** | INSERT 120회 | INSERT 3회 (50+50+20) |

## 🔎 리뷰 요구사항 (선택)

- `WalletRewardBatchRepository`에서 SQL을 직접 작성하므로, 컬럼 누락이나 타입 불일치가 없는지 확인 부탁드립니다.
- JPA 영속성 컨텍스트를 우회하므로, 이후 같은 트랜잭션 내에서 해당 엔티티를 조회할 일이 없는지 확인 부탁드립니다.

## 💬 예상 질문 (선택)

**Q: ID 전략을 SEQUENCE나 UUID로 변경하지 않은 이유는?**
A: 프로젝트 전체 11개 엔티티가 IDENTITY를 사용 중이므로, 일관성을 유지하면서 해당 부분만 JDBC로 처리하는 **최소 침투적 접근**을 선택했습니다.

**Q: `addBatch/executeBatch` 대신 Multi-row INSERT를 사용한 이유는?**
A: MySQL에서는 Multi-row INSERT (`INSERT INTO ... VALUES (...), (...), (...)`)가 addBatch/executeBatch보다 성능이 우수합니다. 또한 JdbcClient의 Fluent API로 가독성도 좋습니다.
