### PR TITLE
QA: 여러 페이지에서 발견된 불필요한 ui 및 텍스트 제거

### DIFF
--- a/frontend/src/features/store-management/components/StampCardStats.tsx
+++ b/frontend/src/features/store-management/components/StampCardStats.tsx
@@ -9,9 +9,9 @@ import {
   Calendar,
   Check,
   ChevronLeft,
+  CreditCard,
   Gift,
   TrendingUp,
-  Users,
 } from "lucide-react";
 
 interface StampCardStatsProps {
@@ -43,7 +43,9 @@ export function StampCardStats({
     return (
       <div className="flex flex-col items-center justify-center p-8 min-h-[400px]">
         <AlertCircle className="w-12 h-12 text-red-500" />
-        <p className="mt-4 text-kkookk-steel">통계 데이터를 불러올 수 없습니다.</p>
+        <p className="mt-4 text-kkookk-steel">
+          통계 데이터를 불러올 수 없습니다.
+        </p>
         <button
           onClick={onBack}
           className="px-4 py-2 mt-4 font-bold border rounded-lg border-slate-200 text-kkookk-navy hover:bg-slate-50"
@@ -77,10 +79,10 @@ export function StampCardStats({
       color: "bg-green-50 text-green-600",
     },
     {
-      title: "활성 이용자",
+      title: "활성 스탬프 카드",
       value: formatNumber(stats.activeUsers),
-      unit: "명",
-      icon: <Users size={20} />,
+      unit: "장",
+      icon: <CreditCard size={20} />,
       color: "bg-purple-50 text-purple-600",
     },
   ];
@@ -113,7 +115,8 @@ export function StampCardStats({
           </div>
         </div>
         <button className="flex items-center gap-2 px-4 py-2 text-sm font-bold bg-white border rounded-lg border-slate-200 text-kkookk-steel">
-          <Calendar size={16} /> {formatDateRange(stats.startDate, stats.endDate)}
+          <Calendar size={16} />{" "}
+          {formatDateRange(stats.startDate, stats.endDate)}
         </button>
       </div>
 
@@ -143,9 +146,7 @@ export function StampCardStats({
       {/* 일별 적립 추이 차트 */}
       <div className="flex flex-col flex-1 min-h-0 p-6 bg-white border shadow-sm rounded-2xl border-slate-200">
         <div className="flex items-center justify-between mb-6">
-          <h4 className="text-lg font-bold text-kkookk-navy">
-            일별 적립 추이
-          </h4>
+          <h4 className="text-lg font-bold text-kkookk-navy">일별 적립 추이</h4>
           <div className="flex items-center gap-1.5 text-xs text-kkookk-steel">
             <div className="w-2.5 h-2.5 bg-kkookk-indigo rounded-full" />
             스탬프 적립
@@ -154,7 +155,9 @@ export function StampCardStats({
 
         {recentDays.length === 0 ? (
           <div className="flex items-center justify-center flex-1">
-            <p className="text-kkookk-steel">조회 기간 내 적립 데이터가 없습니다.</p>
+            <p className="text-kkookk-steel">
+              조회 기간 내 적립 데이터가 없습니다.
+            </p>
           </div>
         ) : (
           <div className="flex items-end justify-between gap-4 px-2 flex-1 min-h-[200px]">

--- a/frontend/src/features/wallet/components/CardDetailView.tsx
+++ b/frontend/src/features/wallet/components/CardDetailView.tsx
@@ -3,43 +3,57 @@
  * 진행 상황 및 액션이 포함된 스탬프 카드 상세 뷰
  */
 
-import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
-import { ChevronLeft, Check, Smartphone, Loader2, AlertCircle, History } from 'lucide-react';
-import { Button } from '@/components/ui/Button';
-import { useCustomerNavigate } from '@/hooks/useCustomerNavigate';
-import { useWalletStampCards, useStoreSummary } from '../hooks/useWallet';
-import { parseDesignJson } from '../utils/cardDesign';
-import type { StampCard } from '@/types/domain';
+import { Button } from "@/components/ui/Button";
+import { useCustomerNavigate } from "@/hooks/useCustomerNavigate";
+import type { StampCard } from "@/types/domain";
+import {
+  AlertCircle,
+  Check,
+  ChevronLeft,
+  History,
+  Loader2,
+  Smartphone,
+} from "lucide-react";
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { useStoreSummary, useWalletStampCards } from "../hooks/useWallet";
+import { parseDesignJson } from "../utils/cardDesign";
 
 export function CardDetailView() {
   const { storeId, customerNavigate } = useCustomerNavigate();
   const { cardId } = useParams<{ cardId: string }>();
   const storeIdNum = storeId ? Number(storeId) : undefined;
 
-  const { data: walletData, isLoading: walletLoading, error: walletError } = useWalletStampCards(storeIdNum);
-  const { data: storeSummary, isLoading: summaryLoading } = useStoreSummary(storeIdNum);
+  const {
+    data: walletData,
+    isLoading: walletLoading,
+    error: walletError,
+  } = useWalletStampCards(storeIdNum);
+  const { data: storeSummary, isLoading: summaryLoading } =
+    useStoreSummary(storeIdNum);
 
   const card: StampCard | null = useMemo(() => {
     // Try to find in wallet data
-    const walletCards: StampCard[] = (walletData?.stampCards ?? []).map((apiCard) => {
-      const style = parseDesignJson(apiCard.designJson);
-      return {
-        id: String(apiCard.walletStampCardId),
-        storeId: apiCard.store.storeId,
-        storeName: apiCard.store.storeName,
-        current: apiCard.currentStampCount,
-        max: apiCard.goalStampCount,
-        reward: apiCard.nextRewardName || '리워드',
-        theme: 'orange' as const,
-        status: 'active' as const,
-        bgGradient: style.bgGradient,
-        shadowColor: style.shadowColor,
-        stampColor: style.stampColor,
-        backgroundImage: style.backgroundImage,
-        stampImage: style.stampImage,
-      };
-    });
+    const walletCards: StampCard[] = (walletData?.stampCards ?? []).map(
+      (apiCard) => {
+        const style = parseDesignJson(apiCard.designJson);
+        return {
+          id: String(apiCard.walletStampCardId),
+          storeId: apiCard.store.storeId,
+          storeName: apiCard.store.storeName,
+          current: apiCard.currentStampCount,
+          max: apiCard.goalStampCount,
+          reward: apiCard.nextRewardName || "리워드",
+          theme: "orange" as const,
+          status: "active" as const,
+          bgGradient: style.bgGradient,
+          shadowColor: style.shadowColor,
+          stampColor: style.stampColor,
+          backgroundImage: style.backgroundImage,
+          stampImage: style.stampImage,
+        };
+      },
+    );
 
     const matched = walletCards.find((c) => c.id === cardId);
     if (matched) return matched;
@@ -53,9 +67,9 @@ export function CardDetailView() {
         storeName: storeSummary.storeName,
         current: 0,
         max: summaryCard.goalStampCount,
-        reward: summaryCard.rewardName || '리워드',
-        theme: 'orange' as const,
-        status: 'active' as const,
+        reward: summaryCard.rewardName || "리워드",
+        theme: "orange" as const,
+        status: "active" as const,
         bgGradient: summaryStyle.bgGradient,
         shadowColor: summaryStyle.shadowColor,
         stampColor: summaryStyle.stampColor,
@@ -86,7 +100,7 @@ export function CardDetailView() {
       <div className="h-full bg-white flex flex-col pt-12">
         <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center">
           <button
-            onClick={() => customerNavigate('/wallet')}
+            onClick={() => customerNavigate("/wallet")}
             className="p-2 -ml-2 text-kkookk-steel"
             aria-label="뒤로 가기"
           >
@@ -95,8 +109,12 @@ export function CardDetailView() {
         </div>
         <div className="flex-1 flex flex-col items-center justify-center p-8">
           <AlertCircle className="w-12 h-12 text-red-500" />
-          <p className="mt-4 text-lg font-medium text-kkookk-navy">카드 정보를 불러올 수 없습니다</p>
-          <p className="mt-1 text-sm text-kkookk-steel">잠시 후 다시 시도해주세요</p>
+          <p className="mt-4 text-lg font-medium text-kkookk-navy">
+            카드 정보를 불러올 수 없습니다
+          </p>
+          <p className="mt-1 text-sm text-kkookk-steel">
+            잠시 후 다시 시도해주세요
+          </p>
         </div>
       </div>
     );
@@ -107,7 +125,7 @@ export function CardDetailView() {
       <div className="h-full bg-white flex flex-col pt-12">
         <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center">
           <button
-            onClick={() => customerNavigate('/wallet')}
+            onClick={() => customerNavigate("/wallet")}
             className="p-2 -ml-2 text-kkookk-steel"
             aria-label="뒤로 가기"
           >
@@ -115,8 +133,12 @@ export function CardDetailView() {
           </button>
         </div>
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
-          <p className="text-lg font-medium text-kkookk-navy">카드를 찾을 수 없습니다</p>
-          <p className="mt-1 text-sm text-kkookk-steel">지갑으로 돌아가서 다시 시도해주세요</p>
+          <p className="text-lg font-medium text-kkookk-navy">
+            카드를 찾을 수 없습니다
+          </p>
+          <p className="mt-1 text-sm text-kkookk-steel">
+            지갑으로 돌아가서 다시 시도해주세요
+          </p>
         </div>
       </div>
     );
@@ -130,7 +152,7 @@ export function CardDetailView() {
       <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center justify-between">
         <div className="flex items-center">
           <button
-            onClick={() => customerNavigate('/wallet')}
+            onClick={() => customerNavigate("/wallet")}
             className="p-2 -ml-2 text-kkookk-steel"
             aria-label="뒤로 가기"
           >
@@ -172,17 +194,23 @@ export function CardDetailView() {
                 key={i}
                 className={`aspect-square rounded-full flex items-center justify-center text-xs font-bold transition-all duration-500 ${
                   isActive
-                    ? `${card.stampColor || 'bg-kkookk-orange-500'} text-white shadow-md scale-100`
-                    : 'bg-kkookk-sand text-kkookk-steel opacity-50 scale-90'
+                    ? `${card.stampColor || "bg-kkookk-orange-500"} text-white shadow-md scale-100`
+                    : "bg-kkookk-sand text-kkookk-steel opacity-50 scale-90"
                 }`}
               >
                 {isActive ? (
                   card.stampImage ? (
-                    <img src={card.stampImage} alt="stamp" className="w-full h-full object-cover rounded-full" />
+                    <img
+                      src={card.stampImage}
+                      alt="stamp"
+                      className="w-full h-full object-cover rounded-full"
+                    />
                   ) : (
                     <Check size={14} strokeWidth={4} />
                   )
-                ) : i + 1}
+                ) : (
+                  i + 1
+                )}
               </div>
             );
           })}
@@ -190,8 +218,6 @@ export function CardDetailView() {
 
         {/* 안내 박스 */}
         <div className="bg-kkookk-sand p-4 rounded-xl text-xs text-kkookk-steel leading-relaxed">
-          <p>• 스탬프 유효기간은 적립일로부터 6개월입니다.</p>
-          <p>• 1일 최대 5개까지 적립 가능합니다.</p>
           <p>• 리워드 사용 시 사장님 확인이 필요합니다.</p>
         </div>
       </div>
@@ -200,7 +226,7 @@ export function CardDetailView() {
       <div className="absolute bottom-0 left-0 w-full bg-white border-t border-slate-100 p-4 pb-8 shadow-[0_-4px_20px_rgba(0,0,0,0.05)]">
         {isComplete ? (
           <Button
-            onClick={() => customerNavigate('/redeems')}
+            onClick={() => customerNavigate("/redeems")}
             variant="navy"
             size="full"
           >


### PR DESCRIPTION
## 🔗 관련 이슈 Closes #113 

## 📌 작업 내용 요약
- 사장님 통계 페이지와 고객 스탬프 적립 페이지에 ui를 수정했습니다.

## 🚀 변경 사항
1. PWA 관련 ui는 현재 main에서 따로 안 보여 작업하지 않았습니다.

2.  **StampCardStats**: KPI 카드 '활성 이용자' → '활성 스탬프 카드'로 명칭 변경, 단위 '명' → '장', 아이콘 `Users` → `CreditCard`로 교체
<img width="289" height="190" alt="활성 이용자 수 -  활성 스탬프 수" src="https://github.com/user-attachments/assets/a62e0edf-e52b-4726-ad4c-9b30be8403cb" />

3. **CardDetailView**: 불필요한 안내 문구 제거 및 코드 포맷팅 정리
<img width="442" height="482" alt="스탬프 적립 안내 문구 after" src="https://github.com/user-attachments/assets/4b6e82e5-66fd-4bfe-803a-eb960a1f262f" />
