### PR TITLE
"내 지갑" 페이지 StampCard ui 개선

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -13,8 +13,6 @@ spring:
 
 server:
   port: 8080
-  tomcat:
-    max-http-post-size: 5MB  # 이미지 포함 API 요청 크기 제한
   servlet:
     encoding:
       charset: UTF-8

--- a/frontend/src/features/store-management/components/StampCardCreateForm.tsx
+++ b/frontend/src/features/store-management/components/StampCardCreateForm.tsx
@@ -41,7 +41,6 @@ const COLOR_OPTIONS = [
 ] as const;
 
 export function StampCardCreateForm({
-  storeName,
   onSubmit,
   onCancel,
 }: StampCardCreateFormProps) {
@@ -171,8 +170,16 @@ export function StampCardCreateForm({
                       : "border-slate-200"
                   }`}
                 >
-                  <div className="flex items-center justify-center h-24 mb-3 border rounded-lg bg-slate-100 border-slate-200 text-slate-400">
-                    <ImageIcon />
+                  <div className="relative flex items-end justify-center h-24 mb-3 overflow-hidden border rounded-lg bg-linear-to-br from-sky-50 to-indigo-50 border-slate-200">
+                    {/* 풍경 장식: 산 + 해 */}
+                    <svg viewBox="0 0 120 48" className="w-full h-12" preserveAspectRatio="xMidYMax slice">
+                      <circle cx="90" cy="12" r="8" className="fill-amber-200/60" />
+                      <path d="M0 48 L30 20 L50 35 L70 15 L100 38 L120 28 L120 48 Z" className="fill-indigo-100/80" />
+                      <path d="M0 48 L20 32 L45 42 L65 28 L90 40 L120 35 L120 48 Z" className="fill-sky-100/90" />
+                    </svg>
+                    <div className="absolute top-2 right-2">
+                      <ImageIcon size={14} className="text-indigo-300" />
+                    </div>
                   </div>
                   <p className="text-sm font-medium text-center text-kkookk-navy">
                     이미지형 (커스텀)
@@ -369,9 +376,9 @@ export function StampCardCreateForm({
                   {design.cardName}
                 </h2>
 
-                {/* 카드 미리보기 */}
+                {/* 카드 미리보기 - 배경만 표시 */}
                 <div
-                  className={`rounded-2xl p-5 mb-6 shadow-lg relative overflow-hidden transition-all duration-300 ${
+                  className={`rounded-2xl aspect-[1.58/1] mb-6 shadow-lg relative overflow-hidden transition-all duration-300 ${
                     design.template === "basic"
                       ? `${getColorClass(design.color)} ${getColorClass(design.color, "shadow")}`
                       : design.backgroundImage
@@ -392,56 +399,30 @@ export function StampCardCreateForm({
                     <div className="absolute inset-0 bg-black/10" />
                   )}
 
-                  <div
-                    className={`flex justify-between items-start mb-6 relative z-10 ${
-                      design.template === "custom" &&
-                      design.textColor === "black"
-                        ? "text-kkookk-navy"
-                        : design.template === "custom" &&
-                            !design.backgroundImage
-                          ? "text-kkookk-navy"
-                          : "text-white"
-                    }`}
-                  >
-                    <span
-                      className={`font-bold opacity-90 ${design.template === "custom" && design.backgroundImage ? "drop-shadow-md" : ""}`}
-                    >
-                      {storeName}
-                    </span>
-                    <span
-                      className={`text-xs px-2 py-1 rounded backdrop-blur-sm shadow-sm ${
-                        design.template === "custom" && !design.backgroundImage
-                          ? "bg-slate-200 text-kkookk-steel"
-                          : "bg-white/20"
-                      }`}
-                    >
-                      D-30
-                    </span>
-                  </div>
-                  <div
-                    className={`flex justify-between items-end relative z-10 ${
-                      design.template === "custom" &&
-                      design.textColor === "black"
-                        ? "text-kkookk-navy"
-                        : design.template === "custom" &&
-                            !design.backgroundImage
-                          ? "text-kkookk-navy"
-                          : "text-white"
-                    }`}
-                  >
-                    <div>
-                      <p
-                        className={`text-xs opacity-70 mb-1 ${design.template === "custom" && design.backgroundImage ? "drop-shadow-sm" : ""}`}
-                      >
-                        진행률
-                      </p>
-                      <p
-                        className={`text-2xl font-bold ${design.template === "custom" && design.backgroundImage ? "drop-shadow-md" : ""}`}
-                      >
-                        3 / {design.maxStamps}
-                      </p>
+                  {/* 단색 카드: 시그니처 고양이 장식 */}
+                  {design.template === "basic" && (
+                    <>
+                      <div
+                        className="absolute -top-16 -right-16 w-48 h-48 rounded-full opacity-[0.08]"
+                        style={{ background: 'radial-gradient(circle, white 0%, transparent 70%)' }}
+                      />
+                      <img
+                        src="/image/cat_pace.png"
+                        alt=""
+                        aria-hidden="true"
+                        className="absolute -right-6 -bottom-6 opacity-[0.07] w-40 h-40 object-cover -rotate-12"
+                      />
+                      <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/[0.08] to-transparent" />
+                    </>
+                  )}
+
+                  {/* 이미지형 미업로드: 빈 이미지 플레이스홀더 */}
+                  {design.template === "custom" && !design.backgroundImage && (
+                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-slate-300">
+                      <ImageIcon size={40} strokeWidth={1.2} />
+                      <span className="text-xs font-medium text-slate-400">배경 이미지를 업로드해 주세요</span>
                     </div>
-                  </div>
+                  )}
                 </div>
 
                 {/* 스탬프 보드 미리보기 */}

--- a/frontend/src/features/wallet/components/CardInfoPanel.tsx
+++ b/frontend/src/features/wallet/components/CardInfoPanel.tsx
@@ -1,0 +1,78 @@
+/**
+ * CardInfoPanel 컴포넌트
+ * 캐러셀 카드 아래: 가게 이름만 표시
+ * 모바일에서만 "스탬프 찍기" 버튼 표시 (showButton)
+ */
+
+import { motion, AnimatePresence } from 'framer-motion'
+import { Smartphone } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { cn } from '@/lib/utils'
+import type { StampCard } from '@/types/domain'
+
+interface CardInfoPanelProps {
+    card: StampCard
+    onStampClick: () => void
+    showButton?: boolean
+    direction?: 1 | -1
+    className?: string
+}
+
+export function CardInfoPanel({ card, onStampClick, showButton = true, direction = 1, className }: CardInfoPanelProps) {
+    const isComplete = card.current >= card.max
+    const slideX = 40 * direction
+
+    return (
+        <div className={cn('w-full max-w-85 mx-auto overflow-hidden', className)}>
+            <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                    key={card.id}
+                    initial={{ opacity: 0, x: slideX }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: -slideX }}
+                    transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
+                    className="flex flex-col items-center"
+                >
+                    {/* 매장명 */}
+                    <h2
+                        className="text-lg font-bold text-kkookk-navy"
+                        style={{ letterSpacing: '-0.02em' }}
+                    >
+                        {card.storeName}
+                    </h2>
+
+                    {/* 액션 버튼 (모바일에서만) */}
+                    {showButton && (
+                        <div className="mt-4 w-full">
+                            {isComplete ? (
+                                <Button
+                                    onClick={onStampClick}
+                                    variant="navy"
+                                    size="full"
+                                    className="h-12 rounded-xl text-sm font-bold"
+                                >
+                                    <Smartphone size={16} className="mr-1.5" />
+                                    리워드 사용하기
+                                </Button>
+                            ) : (
+                                <Button
+                                    onClick={onStampClick}
+                                    variant="primary"
+                                    size="full"
+                                    className="h-12 rounded-xl text-sm font-bold"
+                                    style={{
+                                        boxShadow: '0 4px 14px -3px rgba(255, 77, 0, 0.4), 0 2px 6px -2px rgba(255, 77, 0, 0.2)',
+                                    }}
+                                >
+                                    스탬프 찍기
+                                </Button>
+                            )}
+                        </div>
+                    )}
+                </motion.div>
+            </AnimatePresence>
+        </div>
+    )
+}
+
+export default CardInfoPanel

--- a/frontend/src/features/wallet/components/StampCardBack.tsx
+++ b/frontend/src/features/wallet/components/StampCardBack.tsx
@@ -1,0 +1,109 @@
+/**
+ * StampCardBack 컴포넌트
+ * 카드 뒷면 - 스탬프 진행도 + 보상 정보 + 도장 그리드
+ * 가로형 (1.58:1), backfaceVisibility/rotateY는 부모에서 처리
+ */
+
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { StampCard } from '@/types/domain'
+
+interface StampCardBackProps {
+    card: StampCard
+    className?: string
+}
+
+function getGridCols(max: number): string {
+    if (max <= 5) return 'grid-cols-5'
+    if (max <= 10) return 'grid-cols-5'
+    if (max <= 15) return 'grid-cols-5'
+    return 'grid-cols-5'
+}
+
+export function StampCardBack({ card, className }: StampCardBackProps) {
+    const stampColor = card.stampColor || 'bg-kkookk-orange-500'
+    const gridCols = getGridCols(card.max)
+    const isComplete = card.current >= card.max
+
+    return (
+        <div
+            className={cn(
+                'w-full aspect-[1.58/1] rounded-2xl overflow-hidden relative',
+                'bg-white select-none flex flex-col',
+                className,
+            )}
+        >
+            {/* 보더 */}
+            <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-slate-200/80 pointer-events-none" />
+
+            {/* 상단: 진행률 + 보상 */}
+            <div className="px-4 pt-4 pb-2 shrink-0 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <span className="text-xs font-bold text-kkookk-navy tabular-nums">
+                        {card.current}/{card.max}
+                    </span>
+                    <div className="w-16 h-1 rounded-full bg-slate-100 overflow-hidden">
+                        <div
+                            className={cn('h-full rounded-full', stampColor)}
+                            style={{ width: `${Math.min((card.current / card.max) * 100, 100)}%` }}
+                        />
+                    </div>
+                </div>
+                {card.reward && (
+                    <span className={cn(
+                        'text-[10px] font-semibold px-2 py-0.5 rounded-full',
+                        isComplete
+                            ? 'bg-kkookk-orange-500 text-white'
+                            : 'bg-slate-100 text-slate-500',
+                    )}>
+                        {card.reward}
+                    </span>
+                )}
+            </div>
+
+            {/* 스탬프 그리드 */}
+            <div className={cn(
+                'grid gap-1.5 px-3 pb-3 flex-1 content-center',
+                gridCols,
+                'place-items-center',
+            )}>
+                {Array.from({ length: card.max }).map((_, i) => {
+                    const isActive = i < card.current
+                    return (
+                        <div
+                            key={i}
+                            className={cn(
+                                'aspect-square w-full rounded-full flex items-center justify-center',
+                                'transition-all duration-500',
+                                isActive
+                                    ? cn(stampColor, 'text-white')
+                                    : 'bg-slate-50 text-slate-300 ring-1 ring-inset ring-slate-100',
+                            )}
+                            style={{
+                                boxShadow: isActive
+                                    ? '0 2px 8px -2px rgba(0,0,0,0.15), 0 1px 3px -1px rgba(0,0,0,0.1)'
+                                    : 'none',
+                            }}
+                        >
+                            {isActive ? (
+                                card.stampImage ? (
+                                    <img
+                                        src={card.stampImage}
+                                        alt="stamp"
+                                        className="w-full h-full object-cover rounded-full"
+                                    />
+                                ) : (
+                                    <Check size={14} strokeWidth={3} />
+                                )
+                            ) : (
+                                <span className="text-[9px] font-medium">{i + 1}</span>
+                            )}
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+export default StampCardBack

--- a/frontend/src/features/wallet/components/StampCardCarousel.tsx
+++ b/frontend/src/features/wallet/components/StampCardCarousel.tsx
@@ -1,100 +1,317 @@
 /**
  * StampCardCarousel 컴포넌트
- * 스탬프 카드용 가로 스크롤 캐러셀
+ * 가로형 스탬프 카드 캐러셀 (심플 스케일 전환)
+ * - 중앙 카드: 크게 표시, hover/tap으로 3D 플립
+ * - 좌우 카드: 중앙 기준 좌우에 작게 + 반투명 (PC/모바일 모두)
+ * - 모바일: tap → 플립, 스와이프로 전환, 하단 "스탬프 찍기" 버튼
+ * - PC: hover → 플립, click → 적립요청, 가로 스크롤(휠)로 전환
  */
 
-import { cn } from "@/lib/utils";
-import type { StampCard } from "@/types/domain";
-import { useCallback, useRef, useState } from "react";
-import { StampCardItem } from "./StampCardItem";
+import { useCallback, useState, useEffect, useRef } from 'react'
+import { motion, AnimatePresence, type PanInfo } from 'framer-motion'
+import { cn } from '@/lib/utils'
+import type { StampCard } from '@/types/domain'
+import { StampCardFront } from './StampCardFront'
+import { StampCardBack } from './StampCardBack'
+import { CardInfoPanel } from './CardInfoPanel'
 
 interface StampCardCarouselProps {
-  cards: StampCard[];
-  onCardSelect: (card: StampCard) => void;
-  onCardChange?: (card: StampCard) => void;
-  className?: string;
+    cards: StampCard[]
+    onCardSelect: (card: StampCard) => void
+    onCardChange?: (card: StampCard) => void
+    className?: string
+}
+
+const DRAG_THRESHOLD = 50
+
+const springTransition = {
+    type: 'spring' as const,
+    stiffness: 300,
+    damping: 28,
+}
+
+const flipTransition = {
+    type: 'spring' as const,
+    stiffness: 180,
+    damping: 22,
+}
+
+function useIsTouchDevice() {
+    const [isTouch] = useState(
+        () => typeof window !== 'undefined' && window.matchMedia('(hover: none) and (pointer: coarse)').matches,
+    )
+    return isTouch
 }
 
 export function StampCardCarousel({
-  cards,
-  onCardSelect,
-  onCardChange,
-  className,
+    cards,
+    onCardSelect,
+    onCardChange,
+    className,
 }: StampCardCarouselProps) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
+    const [currentIndex, setCurrentIndex] = useState(0)
+    const [isFlipped, setIsFlipped] = useState(false)
+    const [slideDirection, setSlideDirection] = useState<1 | -1>(1)
+    const isTouchDevice = useIsTouchDevice()
+    const wheelAccum = useRef(0)
+    const wheelTimer = useRef<ReturnType<typeof setTimeout>>()
+    const carouselRef = useRef<HTMLDivElement>(null)
 
-  const handleScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const target = e.target as HTMLDivElement;
-      const scrollLeft = target.scrollLeft;
-      const width = target.offsetWidth;
-      const cardWidth = width * 0.85;
-      const index = Math.min(Math.max(Math.round(scrollLeft / cardWidth), 0), cards.length - 1);
-      if (index !== currentIndex) {
-        setCurrentIndex(index);
-        onCardChange?.(cards[index]);
-      }
-    },
-    [cards, currentIndex, onCardChange],
-  );
+    const goTo = useCallback(
+        (index: number, direction?: 1 | -1) => {
+            const clamped = Math.max(0, Math.min(index, cards.length - 1))
+            if (clamped !== currentIndex) {
+                setSlideDirection(direction ?? (clamped > currentIndex ? 1 : -1))
+                setCurrentIndex(clamped)
+                setIsFlipped(false)
+                onCardChange?.(cards[clamped])
+            }
+        },
+        [cards, currentIndex, onCardChange],
+    )
 
-  return (
-    <div className={cn("flex flex-col", className)}>
-      {/* 캐러셀 */}
-      {cards.length === 1 ? (
-        <div className="flex justify-center px-6 py-6">
-          <div className="w-[85%] max-w-sm">
-            <StampCardItem
-              card={cards[0]}
-              isActive
-              onClick={() => onCardSelect(cards[0])}
-            />
-          </div>
-        </div>
-      ) : (
-        <>
-          <div
-            ref={scrollRef}
-            className="flex overflow-x-auto snap-x snap-mandatory px-[7.5%] gap-4 no-scrollbar items-center py-6"
-            onScroll={handleScroll}
-          >
-            {cards.map((card, index) => (
-              <div
-                key={card.id}
-                className="snap-center shrink-0 w-[85%] transition-all duration-300"
+    const handleDragEnd = useCallback(
+        (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+            if (Math.abs(info.offset.x) > DRAG_THRESHOLD) {
+                if (info.offset.x > 0 && currentIndex > 0) {
+                    goTo(currentIndex - 1, -1)
+                } else if (info.offset.x < 0 && currentIndex < cards.length - 1) {
+                    goTo(currentIndex + 1, 1)
+                }
+            }
+        },
+        [currentIndex, cards.length, goTo],
+    )
+
+    const handleCenterClick = useCallback(() => {
+        if (isTouchDevice) {
+            setIsFlipped((prev) => !prev)
+        } else {
+            onCardSelect(cards[currentIndex])
+        }
+    }, [isTouchDevice, onCardSelect, cards, currentIndex])
+
+    const handleHoverStart = useCallback(() => {
+        if (!isTouchDevice) {
+            setIsFlipped(true)
+        }
+    }, [isTouchDevice])
+
+    const handleHoverEnd = useCallback(() => {
+        if (!isTouchDevice) {
+            setIsFlipped(false)
+        }
+    }, [isTouchDevice])
+
+    // PC: 가로 스크롤(휠/트랙패드)로 캐러셀 전환
+    // 항상 preventDefault로 Mac 브라우저 뒤로/앞으로 방지
+    // delta 누적 방식으로 트랙패드 민감도 개선
+    useEffect(() => {
+        const el = carouselRef.current
+        if (!el || isTouchDevice) return
+
+        const ACCUM_THRESHOLD = 15
+
+        const handleWheel = (e: WheelEvent) => {
+            // 항상 preventDefault → Mac 브라우저 뒤로가기/앞으로가기 방지
+            e.preventDefault()
+
+            const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
+            wheelAccum.current += delta
+
+            // 리셋 타이머: 스크롤 멈추면 누적값 초기화
+            clearTimeout(wheelTimer.current)
+            wheelTimer.current = setTimeout(() => { wheelAccum.current = 0 }, 150)
+
+            if (Math.abs(wheelAccum.current) >= ACCUM_THRESHOLD) {
+                const dir = wheelAccum.current > 0 ? 1 : -1
+                wheelAccum.current = 0
+                if (dir > 0) {
+                    goTo(currentIndex + 1, 1)
+                } else {
+                    goTo(currentIndex - 1, -1)
+                }
+            }
+        }
+
+        el.addEventListener('wheel', handleWheel, { passive: false })
+        return () => {
+            el.removeEventListener('wheel', handleWheel)
+            clearTimeout(wheelTimer.current)
+        }
+    }, [currentIndex, goTo, isTouchDevice])
+
+    // 키보드 네비게이션
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            switch (e.key) {
+                case 'ArrowLeft':
+                    goTo(currentIndex - 1)
+                    break
+                case 'ArrowRight':
+                    goTo(currentIndex + 1)
+                    break
+                case 'Enter':
+                case ' ':
+                    e.preventDefault()
+                    setIsFlipped((prev) => !prev)
+                    break
+                case 'Escape':
+                    setIsFlipped(false)
+                    break
+            }
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [currentIndex, goTo])
+
+    const currentCard = cards[currentIndex]
+    const prevCard = currentIndex > 0 ? cards[currentIndex - 1] : null
+    const nextCard = currentIndex < cards.length - 1 ? cards[currentIndex + 1] : null
+
+    // 좌우 카드 위치: 중앙 카드 기준 좌우로 배치 (PC에서도 보이게)
+    const SIDE_OFFSET = 58 // 중앙에서 좌/우 %
+
+    return (
+        <div
+            className={cn('flex flex-col items-center', className)}
+            role="region"
+            aria-label="스탬프 카드 캐러셀"
+            aria-roledescription="carousel"
+        >
+            {/* 캐러셀 영역 - 100vw */}
+            <div
+                ref={carouselRef}
+                className="relative w-screen overflow-hidden flex items-center justify-center"
                 style={{
-                  transform: currentIndex === index ? "scale(1)" : "scale(0.95)",
-                  opacity: currentIndex === index ? 1 : 0.7,
+                    perspective: '1200px',
+                    height: '240px',
                 }}
-              >
-                <StampCardItem
-                  card={card}
-                  isActive={currentIndex === index}
-                  onClick={() => onCardSelect(card)}
-                />
-              </div>
-            ))}
-          </div>
+            >
+                {/* 좌측 카드 (중앙 기준 왼쪽) */}
+                <AnimatePresence mode="popLayout">
+                    {prevCard && (
+                        <motion.div
+                            key={`prev-${prevCard.id}`}
+                            className="absolute cursor-pointer"
+                            style={{
+                                width: '70%',
+                                maxWidth: 300,
+                                zIndex: 1,
+                                left: '50%',
+                            }}
+                            initial={{ opacity: 0, x: `-${SIDE_OFFSET + 40}%` }}
+                            animate={{ opacity: 0.5, x: `-${SIDE_OFFSET + 50}%`, scale: 0.8 }}
+                            exit={{ opacity: 0, x: `-${SIDE_OFFSET + 40}%` }}
+                            transition={springTransition}
+                            onClick={() => goTo(currentIndex - 1)}
+                        >
+                            <StampCardFront card={prevCard} />
+                        </motion.div>
+                    )}
+                </AnimatePresence>
 
-          {/* 페이지네이션 점 */}
-          <div className="flex justify-center gap-2 mt-6">
-            {cards.map((_, i) => (
-              <div
-                key={i}
-                className={cn(
-                  "h-1.5 rounded-full transition-all duration-300",
-                  i === currentIndex
-                    ? "bg-kkookk-orange-500 w-4"
-                    : "bg-slate-300 w-1.5",
-                )}
-              />
-            ))}
-          </div>
-        </>
-      )}
-    </div>
-  );
+                {/* 중앙 카드 (3D 플립) */}
+                <motion.div
+                    className="relative cursor-pointer isolate"
+                    style={{ width: '78%', maxWidth: 340, zIndex: 10 }}
+                    {...(isTouchDevice ? {
+                        drag: 'x' as const,
+                        dragConstraints: { left: 0, right: 0 },
+                        dragElastic: 0.15,
+                        dragMomentum: false,
+                        onDragEnd: handleDragEnd,
+                        whileDrag: { scale: 0.97 },
+                    } : {})}
+                    onHoverStart={handleHoverStart}
+                    onHoverEnd={handleHoverEnd}
+                    transition={springTransition}
+                    role="group"
+                    aria-roledescription="slide"
+                    aria-label={`${currentIndex + 1} / ${cards.length}: ${currentCard?.storeName}`}
+                    tabIndex={0}
+                >
+                    {/* 그림자 - 3D 컨테이너 바깥, 부드러운 디퓨즈 */}
+                    <div
+                        className="absolute -inset-2 rounded-3xl pointer-events-none"
+                        style={{
+                            background: 'radial-gradient(ellipse at 50% 60%, rgba(0,0,0,0.12) 0%, transparent 70%)',
+                            filter: 'blur(12px)',
+                            transform: 'translateY(8px)',
+                        }}
+                    />
+
+                    <motion.div
+                        className="relative"
+                        style={{ transformStyle: 'preserve-3d' }}
+                        animate={{ rotateY: isFlipped ? 180 : 0 }}
+                        transition={flipTransition}
+                        onClick={handleCenterClick}
+                    >
+                        {/* 불투명 백킹: 사이드 카드가 비치는 것 차단 (앞면용/뒷면용) */}
+                        <div
+                            className="absolute inset-0 rounded-2xl bg-white"
+                            style={{ transform: 'translateZ(-1px)', backfaceVisibility: 'hidden' }}
+                        />
+                        <div
+                            className="absolute inset-0 rounded-2xl bg-white"
+                            style={{ transform: 'rotateY(180deg) translateZ(-1px)', backfaceVisibility: 'hidden' }}
+                        />
+
+                        {/* 앞면 */}
+                        <div style={{ backfaceVisibility: 'hidden' }}>
+                            <StampCardFront card={currentCard} />
+                        </div>
+
+                        {/* 뒷면 */}
+                        <div
+                            className="absolute inset-0"
+                            style={{
+                                backfaceVisibility: 'hidden',
+                                transform: 'rotateY(180deg)',
+                            }}
+                        >
+                            <StampCardBack card={currentCard} />
+                        </div>
+                    </motion.div>
+                </motion.div>
+
+                {/* 우측 카드 (중앙 기준 오른쪽) */}
+                <AnimatePresence mode="popLayout">
+                    {nextCard && (
+                        <motion.div
+                            key={`next-${nextCard.id}`}
+                            className="absolute cursor-pointer"
+                            style={{
+                                width: '70%',
+                                maxWidth: 300,
+                                zIndex: 1,
+                                left: '50%',
+                            }}
+                            initial={{ opacity: 0, x: `${SIDE_OFFSET - 10}%` }}
+                            animate={{ opacity: 0.5, x: `${SIDE_OFFSET - 50}%`, scale: 0.8 }}
+                            exit={{ opacity: 0, x: `${SIDE_OFFSET - 10}%` }}
+                            transition={springTransition}
+                            onClick={() => goTo(currentIndex + 1)}
+                        >
+                            <StampCardFront card={nextCard} />
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            </div>
+
+            {/* 카드 정보: 가게 이름만 + 모바일만 버튼 */}
+            {currentCard && (
+                <CardInfoPanel
+                    card={currentCard}
+                    onStampClick={() => onCardSelect(currentCard)}
+                    showButton={isTouchDevice}
+                    direction={slideDirection}
+                    className="mt-5"
+                />
+            )}
+        </div>
+    )
 }
 
-export default StampCardCarousel;
+export default StampCardCarousel

--- a/frontend/src/features/wallet/components/StampCardFront.tsx
+++ b/frontend/src/features/wallet/components/StampCardFront.tsx
@@ -1,0 +1,83 @@
+/**
+ * StampCardFront 컴포넌트
+ * 카드 앞면 - 순수 비주얼만 (배경 그라데이션 또는 이미지)
+ * 텍스트/정보 없음, 3D 플립의 앞면
+ * backfaceVisibility는 부모(캐러셀)에서 처리
+ */
+
+import { cn } from '@/lib/utils'
+import type { StampCard } from '@/types/domain'
+
+interface StampCardFrontProps {
+    card: StampCard
+    className?: string
+}
+
+export function StampCardFront({ card, className }: StampCardFrontProps) {
+    const hasBackgroundImage = !!card.backgroundImage
+    const bgGradient =
+        card.bgGradient || 'from-[var(--color-kkookk-orange-500)] to-[#E04F00]'
+
+    return (
+        <div
+            className={cn(
+                'w-full aspect-[1.58/1] rounded-2xl overflow-hidden relative',
+                'select-none',
+                !hasBackgroundImage && 'bg-linear-to-br',
+                !hasBackgroundImage && bgGradient,
+                className,
+            )}
+            style={
+                hasBackgroundImage
+                    ? {
+                          backgroundImage: `url(${card.backgroundImage})`,
+                          backgroundSize: 'cover',
+                          backgroundPosition: 'center',
+                      }
+                    : undefined
+            }
+        >
+            {/* 이미지형 글래스 오버레이 */}
+            {hasBackgroundImage && (
+                <div className="absolute inset-0 bg-black/10" />
+            )}
+
+            {/* COLOR 타입 장식 요소 */}
+            {!hasBackgroundImage && (
+                <>
+                    {/* 상단 대각선 라이트 */}
+                    <div
+                        className="absolute -top-20 -right-20 w-60 h-60 rounded-full opacity-[0.08]"
+                        style={{
+                            background: 'radial-gradient(circle, white 0%, transparent 70%)',
+                        }}
+                    />
+
+                    {/* 고양이 장식 아이콘 */}
+                    <img
+                        src="/image/cat_pace.png"
+                        alt=""
+                        aria-hidden="true"
+                        className="absolute -right-8 -bottom-8 opacity-[0.07] w-52 h-52 object-cover -rotate-12"
+                    />
+
+                    {/* 하단 그라데이션 깊이감 */}
+                    <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-t from-black/8 to-transparent" />
+                </>
+            )}
+
+            {/* 미세한 노이즈 텍스처 오버레이 */}
+            <div
+                className="absolute inset-0 opacity-[0.03] mix-blend-overlay pointer-events-none"
+                style={{
+                    backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+                }}
+            />
+
+            {/* 인너 보더 하이라이트 */}
+            <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/15 pointer-events-none" />
+        </div>
+    )
+}
+
+export default StampCardFront

--- a/frontend/src/features/wallet/components/index.ts
+++ b/frontend/src/features/wallet/components/index.ts
@@ -2,7 +2,9 @@
  * Wallet Components Index
  */
 
-export * from './StampCardItem';
+export * from './StampCardFront';
+export * from './StampCardBack';
 export * from './StampCardCarousel';
+export * from './CardInfoPanel';
 export * from './CardDetailView';
 export * from './WalletHeader';

--- a/frontend/src/features/wallet/pages/WalletPage.tsx
+++ b/frontend/src/features/wallet/pages/WalletPage.tsx
@@ -100,7 +100,12 @@ export function WalletPage() {
   };
 
   const handleCardSelect = (card: StampCard) => {
-    customerNavigate(`/wallet/${card.id}`);
+    const isComplete = card.current >= card.max;
+    if (isComplete) {
+      customerNavigate('/redeems');
+    } else {
+      customerNavigate(`/wallet/${card.id}/stamp`);
+    }
   };
 
   // Loading state
@@ -155,7 +160,7 @@ export function WalletPage() {
     <div className="flex-1 flex flex-col min-h-screen">
       <WalletHeader onMenuClick={() => setIsMenuOpen(true)} />
 
-      <div className="flex-1 flex flex-col justify-center">
+      <div className="flex-1 flex flex-col justify-center pb-8">
         <StampCardCarousel cards={cards} onCardSelect={handleCardSelect} onCardChange={handleCardChange} />
       </div>
     </div>

--- a/frontend/src/pages/owner/StoreDetailPage.tsx
+++ b/frontend/src/pages/owner/StoreDetailPage.tsx
@@ -17,7 +17,6 @@ import {
   AlertTriangle,
   BarChart3,
   ChevronLeft,
-  Coffee,
   Edit,
   Loader2,
   MapPin,
@@ -77,19 +76,13 @@ const COLOR_GRADIENT_MAP: Record<string, [string, string]> = {
 };
 
 function ActiveCardPreview({
-  storeName,
   designType,
   designJson,
   designLoading,
-  expireDays,
-  goalStampCount,
 }: {
-  storeName: string;
   designType: StampCardDesignType;
   designJson: string | null;
   designLoading: boolean;
-  expireDays: number | null;
-  goalStampCount: number;
 }) {
   // 디자인 정보 로딩 중
   if (designLoading) {
@@ -122,25 +115,29 @@ function ActiveCardPreview({
 
   return (
     <div
-      className="relative flex flex-col h-48 p-6 overflow-hidden text-white shadow-lg w-80 rounded-xl shrink-0"
+      className="relative h-48 overflow-hidden shadow-lg w-80 rounded-xl shrink-0"
       style={bgStyle}
     >
       {hasBackgroundImage && (
-        <div className="absolute inset-0 bg-black/30 rounded-xl" />
+        <div className="absolute inset-0 bg-black/10 rounded-xl" />
       )}
-      <div className="relative z-10 flex items-start justify-between mb-4">
-        <span className="text-lg font-bold opacity-90">{storeName}</span>
-        <span className="px-2 py-1 text-xs rounded bg-white/20">
-          {expireDays ? `D-${expireDays}` : "무기한"}
-        </span>
-      </div>
-      <div className="relative z-10 flex items-end justify-between mt-auto">
-        <div>
-          <p className="mb-1 text-xs opacity-80">목표</p>
-          <p className="text-2xl font-bold">0 / {goalStampCount}</p>
-        </div>
-        <Coffee className="absolute w-16 h-16 text-white/20 -right-4 -bottom-4" />
-      </div>
+
+      {/* 단색 카드: 시그니처 고양이 장식 */}
+      {!hasBackgroundImage && (
+        <>
+          <div
+            className="absolute -top-16 -right-16 w-48 h-48 rounded-full opacity-[0.08]"
+            style={{ background: 'radial-gradient(circle, white 0%, transparent 70%)' }}
+          />
+          <img
+            src="/image/cat_pace.png"
+            alt=""
+            aria-hidden="true"
+            className="absolute -right-6 -bottom-6 opacity-[0.07] w-40 h-40 object-cover -rotate-12"
+          />
+          <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/[0.08] to-transparent" />
+        </>
+      )}
     </div>
   );
 }
@@ -512,12 +509,9 @@ export function StoreDetailPage() {
                     <div className="flex items-center gap-8 p-6 transition-shadow bg-white border shadow-sm rounded-2xl border-slate-200 hover:shadow-md">
                       {/* 카드 미리보기 */}
                       <ActiveCardPreview
-                        storeName={store.name}
                         designType={activeCard.designType}
                         designJson={activeCardDetail?.designJson ?? null}
                         designLoading={activeCardDetailLoading}
-                        expireDays={activeCard.expireDays}
-                        goalStampCount={activeCard.goalStampCount}
                       />
 
                       {/* 카드 정보 */}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #125 

## 📌 작업 내용 요약
"내 지갑" 페이지 전반적인 ui 개선 작업입니다.

## 🚀 변경 사항
### 1. "내 지갑" 페이지 스탬프 카드 캐러셀 UI/UX 개선
- 인터랙션 수정: 스탬프 카드에 Hover 시 스탬프 판이 노출되도록 변경했습니다. 페이지 이동은 클릭 시에만 "스탬프 적립 요청하기"로 연결되도록 분리하여 의도치 않은 이동을 방지했습니다.
- 가독성 해결: 가게 정보 배경 설정 시 텍스트가 묻히는 이슈를 해결하기 위해, 텍스트를 카드 내부가 아닌 카드 외부로 배치하는 방식을 선택했습니다.
- 레이아웃 결정: 카드 세로 배치로 크게 보여주는 방식을 검토했으나, Hover 시 뒷면의 세로 Grid 구조가 시각적으로 부자연스러워 기존의 가로 레이아웃을 유지하기로 결정했습니다.
- 관리자 페이지 동기화: 스탬프 카드를 배경 중심으로 변경함에 따라, 관리자 페이지 내 StampCard UI의 텍스트 노출 방식도 통일성 있게 전면 수정했습니다.

### 2. 관리자 페이지 템플릿 및 미리보기 UI 수정
미리보기 강화: 관리자 페이지 내 '템플릿 선택 -> 이미지' 과정과 이미지 부재 시의 미리보기(Preview) UI를 개선했습니다. 상세 내용은 Preview를 통해 확인하실 수 있습니다.


## 📎 참고 자료 (선택)

### "지갑 홈" 스탬프 카드 목록 ui
https://github.com/user-attachments/assets/7b885d7b-166d-4115-b457-02b9146b31c3

### 그 외
<img width="364" height="313" alt="이미지없음" src="https://github.com/user-attachments/assets/7f6a54f2-8cf2-450b-8d1a-9e7c15cd93a3" />
<img width="381" height="277" alt="템플릿선택" src="https://github.com/user-attachments/assets/d3489403-171f-411d-a388-5ab783e70a88" />
<img width="867" height="411" alt="Active카드" src="https://github.com/user-attachments/assets/78b6c716-052e-4ef1-9e5a-430dffb9ec91" />
