### PR TITLE
관리자페이지 -> 적립/사용내역 GET 요청 안되는 문제 + "구분" 요소 ui 개선

### DIFF
--- a/frontend/src/pages/owner/StoreHistoryPage.tsx
+++ b/frontend/src/pages/owner/StoreHistoryPage.tsx
@@ -18,6 +18,7 @@ interface HistoryItem {
   user: string;
   phone: string;
   type: 'stamp' | 'reward';
+  stampEventType?: 'ISSUED' | 'MIGRATED' | 'MANUAL_ADJUST';
   count?: number;
   content: string;
 }
@@ -63,12 +64,13 @@ export function StoreHistoryPage() {
       user: event.customerNickname,
       phone: event.customerPhone,
       type: 'stamp' as const,
+      stampEventType: event.type,
       count: event.delta,
       content: `+${event.delta}`,
     }));
 
     const rewardHistory: HistoryItem[] = (redeemEventsData?.content ?? [])
-      .filter((event) => event.type === 'COMPLETED' && event.result === 'SUCCESS')
+      .filter((event) => event.result === 'SUCCESS')
       .map((event) => ({
         id: `redeem-${event.id}`,
         time: event.occurredAt,
@@ -239,11 +241,17 @@ export function StoreHistoryPage() {
                           <span
                             className={`text-xs font-bold px-2 py-1 rounded ${
                               item.type === 'stamp'
-                                ? 'bg-blue-50 text-kkookk-indigo'
+                                ? item.stampEventType === 'MIGRATED'
+                                  ? 'bg-yellow-50 text-yellow-600'
+                                  : 'bg-blue-50 text-kkookk-indigo'
                                 : 'bg-purple-100 text-purple-700'
                             }`}
                           >
-                            {item.type === 'stamp' ? '적립' : '사용'}
+                            {item.type === 'stamp'
+                              ? item.stampEventType === 'MIGRATED'
+                                ? '전환 적립'
+                                : '스탬프 적립'
+                              : '리워드 사용'}
                           </span>
                         </td>
                         <td className="p-4 text-sm text-right pr-6 font-bold text-kkookk-navy">


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #140 

## 📌 작업 내용 요약
적립/사용내역 fetch 안되는 문제, "스탬프 적립" "전환 적립" "리워드 사용" 구분요소 ui 개선 작업입니다.

## 🚀 변경 사항
1. ReddemSessino 제거하면서 프론트엔드 동기화 필요한 코드 일부 수정했습니다. 스탬프 적립, 리워드 사용 GET api 정상 작동하는 것 확인했습니다.
2. 적립/사용 내역에서 "구분" 요소 ui를 더 명확히 구분했습니다
<img width="140" height="333" alt="스크린샷 2026-02-18 오후 1 30 16" src="https://github.com/user-attachments/assets/4f589053-d26e-49f3-bf37-25bdfa0bf606" />
