### PR TITLE
랜딩 페이지에서 직접 고객 로그인 플로우 추가

### DIFF
--- a/backend/src/main/java/com/project/kkookk/wallet/controller/WalletApi.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/controller/WalletApi.java
@@ -46,7 +46,10 @@ public interface WalletApi {
 
     @Operation(
             summary = "고객 로그인",
-            description = "전화번호와 이름으로 기존 고객 로그인을 수행합니다. 해당 매장의 스탬프카드가 없으면 자동 발급합니다.")
+            description =
+                    "전화번호와 이름으로 기존 고객 로그인을 수행합니다. "
+                            + "storeId가 있으면 해당 매장의 스탬프카드를 자동 발급하고 우선 표시합니다. "
+                            + "storeId가 없으면 모든 스탬프카드를 최근 적립순으로 반환합니다.")
     @ApiResponses(
             value = {
                 @ApiResponse(

--- a/backend/src/main/java/com/project/kkookk/wallet/dto/CustomerLoginRequest.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/dto/CustomerLoginRequest.java
@@ -2,7 +2,6 @@ package com.project.kkookk.wallet.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -16,5 +15,5 @@ public record CustomerLoginRequest(
                 @NotBlank(message = "이름은 필수입니다")
                 @Size(max = 50, message = "이름은 50자 이하여야 합니다")
                 String name,
-        @Schema(description = "매장 ID", example = "1") @NotNull(message = "매장 ID는 필수입니다")
+        @Schema(description = "매장 ID (QR 스캔 진입 시 필수, 직접 로그인 시 선택)", example = "1", nullable = true)
                 Long storeId) {}

--- a/backend/src/main/java/com/project/kkookk/wallet/service/CustomerWalletService.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/service/CustomerWalletService.java
@@ -161,10 +161,12 @@ public class CustomerWalletService {
             throw new CustomerWalletBlockedException("차단된 지갑입니다");
         }
 
-        // 3. 해당 매장의 스탬프카드가 있는지 확인, 없으면 생성
-        ensureWalletStampCardExists(wallet.getId(), request.storeId());
+        // 3. 해당 매장의 스탬프카드가 있는지 확인, 없으면 생성 (storeId가 있을 때만)
+        if (request.storeId() != null) {
+            ensureWalletStampCardExists(wallet.getId(), request.storeId());
+        }
 
-        // 4. 고객의 모든 ACTIVE 스탬프카드 조회 (현재 매장 카드 우선)
+        // 4. 고객의 모든 ACTIVE 스탬프카드 조회 (storeId 있으면 현재 매장 카드 우선, 없으면 최근 적립순)
         List<WalletStampCardSummary> stampCards =
                 getAllStampCardsWithCurrentStoreFirst(wallet.getId(), request.storeId());
 
@@ -229,18 +231,21 @@ public class CustomerWalletService {
                 storeRepository.findAllById(storeIds).stream()
                         .collect(Collectors.toMap(Store::getId, Function.identity()));
 
-        // 현재 매장 카드를 첫 번째로 정렬
+        // currentStoreId가 있으면 현재 매장 카드를 첫 번째로 정렬, 없으면 최근 적립순으로만 정렬
         walletCards.sort(
                 (a, b) -> {
-                    boolean firstIsCurrentStore = a.getStoreId().equals(currentStoreId);
-                    boolean secondIsCurrentStore = b.getStoreId().equals(currentStoreId);
-                    if (firstIsCurrentStore && !secondIsCurrentStore) {
-                        return -1;
+                    // currentStoreId가 null이면 스토어 우선순위 건너뛰기
+                    if (currentStoreId != null) {
+                        boolean firstIsCurrentStore = a.getStoreId().equals(currentStoreId);
+                        boolean secondIsCurrentStore = b.getStoreId().equals(currentStoreId);
+                        if (firstIsCurrentStore && !secondIsCurrentStore) {
+                            return -1;
+                        }
+                        if (!firstIsCurrentStore && secondIsCurrentStore) {
+                            return 1;
+                        }
                     }
-                    if (!firstIsCurrentStore && secondIsCurrentStore) {
-                        return 1;
-                    }
-                    // 같은 경우 최근 적립 순
+                    // currentStoreId가 null이거나 같은 경우 최근 적립 순
                     if (a.getLastStampedAt() == null && b.getLastStampedAt() == null) {
                         return 0;
                     }

--- a/backend/src/test/java/com/project/kkookk/wallet/service/CustomerWalletServiceTest.java
+++ b/backend/src/test/java/com/project/kkookk/wallet/service/CustomerWalletServiceTest.java
@@ -502,4 +502,52 @@ class CustomerWalletServiceTest {
         assertThat(available).isFalse();
         verify(customerWalletRepository).existsByNickname("길동이");
     }
+
+    @Test
+    @DisplayName("고객 로그인 실패 - 지갑을 찾을 수 없음")
+    void login_Fail_WalletNotFound() {
+        // given
+        com.project.kkookk.wallet.dto.CustomerLoginRequest request =
+                new com.project.kkookk.wallet.dto.CustomerLoginRequest(
+                        "010-9999-9999", "존재하지않음", 1L);
+
+        given(customerWalletRepository.findByPhoneAndName("01099999999", "존재하지않음"))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> customerWalletService.login(request))
+                .isInstanceOf(
+                        com.project.kkookk.wallet.service.exception.CustomerWalletNotFoundException
+                                .class)
+                .hasMessageContaining("해당 전화번호와 이름으로 지갑을 찾을 수 없습니다");
+
+        verify(customerWalletRepository).findByPhoneAndName("01099999999", "존재하지않음");
+        verify(jwtUtil, never()).generateCustomerToken(anyLong());
+    }
+
+    @Test
+    @DisplayName("고객 로그인 실패 - 차단된 지갑")
+    void login_Fail_WalletBlocked() {
+        // given
+        com.project.kkookk.wallet.dto.CustomerLoginRequest request =
+                new com.project.kkookk.wallet.dto.CustomerLoginRequest("010-1234-5678", "홍길동", 1L);
+
+        CustomerWallet blockedWallet =
+                CustomerWallet.builder().phone("01012345678").name("홍길동").nickname("길동이").build();
+        ReflectionTestUtils.setField(blockedWallet, "id", 1L);
+        blockedWallet.block();
+
+        given(customerWalletRepository.findByPhoneAndName("01012345678", "홍길동"))
+                .willReturn(Optional.of(blockedWallet));
+
+        // when & then
+        assertThatThrownBy(() -> customerWalletService.login(request))
+                .isInstanceOf(
+                        com.project.kkookk.wallet.service.exception.CustomerWalletBlockedException
+                                .class)
+                .hasMessageContaining("차단된 지갑입니다");
+
+        verify(customerWalletRepository).findByPhoneAndName("01012345678", "홍길동");
+        verify(jwtUtil, never()).generateCustomerToken(anyLong());
+    }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,7 +65,7 @@
 | Method | Path | Handler | Description |
 |--------|------|---------|-------------|
 | POST | `/api/public/wallet/register` | `WalletController.register()` | 신규 고객 지갑 등록 (OTP 인증 후) |
-| POST | `/api/public/wallet/login` | `WalletController.login()` | 고객 로그인 (전화번호 + 이름, 자동 스탬프카드 발급) |
+| POST | `/api/public/wallet/login` | `WalletController.login()` | 고객 로그인 (전화번호 + 이름, storeId 선택). storeId 있으면 자동 스탬프카드 발급 및 우선 표시, 없으면 최근 적립순 정렬 |
 | GET | `/api/public/wallet/check-nickname?nickname={nickname}` | `WalletController.checkNickname()` | 닉네임 중복 체크 |
 | GET | `/api/public/wallet/check-phone?phone={phone}` | `WalletController.checkPhone()` | 전화번호 중복 체크 |
 

--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -9,6 +9,7 @@ import { OwnerLayout } from "@/app/layouts/OwnerLayout";
 import { TerminalLayout } from "@/app/layouts/TerminalLayout";
 import { LandingPage } from "@/pages/LandingPage";
 import { LauncherPage } from "@/pages/LauncherPage";
+import { RoleSelectionPage } from "@/pages/RoleSelectionPage";
 import { createBrowserRouter, Navigate } from "react-router-dom";
 
 // 고객 페이지
@@ -16,6 +17,7 @@ import { CustomerHistoryPage } from "@/pages/customer/CustomerHistoryPage";
 import { CustomerLandingPage } from "@/pages/customer/CustomerLandingPage";
 import { CustomerSettingsPage } from "@/pages/customer/CustomerSettingsPage";
 import { CustomerStoreSelectPage } from "@/pages/customer/CustomerStoreSelectPage";
+import { DirectCustomerLoginPage } from "@/pages/customer/DirectCustomerLoginPage";
 
 // 고객 기능 컴포넌트 (페이지로 래핑될 예정)
 import { CustomerLoginForm, CustomerSignupForm } from "@/features/auth";
@@ -64,6 +66,11 @@ export const router = createBrowserRouter([
     element: <LauncherPage />,
   },
 
+  // 역할 선택 페이지 (진입점)
+  {
+    path: "/funnel",
+    element: <RoleSelectionPage />,
+  },
 
   // 고객 매장 선택 (시뮬레이션 진입점)
   {
@@ -79,6 +86,15 @@ export const router = createBrowserRouter([
       { index: true, element: <CustomerLandingPage /> },
       { path: "login", element: <CustomerLoginForm /> },
       { path: "signup", element: <CustomerSignupForm /> },
+    ],
+  },
+
+  // 직접 고객 로그인 (storeId 없음 - funnel에서 진입)
+  {
+    path: "/customer/login",
+    element: <CustomerLayout />,
+    children: [
+      { index: true, element: <DirectCustomerLoginPage /> },
     ],
   },
 

--- a/frontend/src/assets/styles/index.css
+++ b/frontend/src/assets/styles/index.css
@@ -78,10 +78,17 @@ button {
 @theme {
   /* KKOOKK Orange Scale */
   --color-kkookk-orange-50: #fff7ed;
+  --color-kkookk-orange-100: #ffedd5;
   --color-kkookk-orange-200: #fed7aa;
   --color-kkookk-orange-500: #ff4d00;
   --color-kkookk-orange-600: #ea580c;
   --color-kkookk-orange-900: #7c2d12;
+
+  /* KKOOKK Indigo Scale (Owner Persona) */
+  --color-kkookk-indigo-50: #eef2ff;
+  --color-kkookk-indigo-100: #e0e7ff;
+  --color-kkookk-indigo-200: #c7d2fe;
+  --color-kkookk-indigo-500: #2e58ff;
 
   /* Status */
   --color-kkookk-red: #dc2626;

--- a/frontend/src/features/auth/components/CustomerLoginForm.tsx
+++ b/frontend/src/features/auth/components/CustomerLoginForm.tsx
@@ -27,7 +27,7 @@ export function CustomerLoginForm() {
 
   const phoneDigitCount = stripPhoneToDigits(phone).length;
   const isPhoneComplete = phoneDigitCount >= 10 && phoneDigitCount <= 11;
-  const isFormValid = name.trim() !== '' && isPhoneComplete && !phoneError && !!storeId;
+  const isFormValid = name.trim() !== '' && isPhoneComplete && !phoneError;
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
@@ -45,7 +45,11 @@ export function CustomerLoginForm() {
     if (!isFormValid) return;
 
     loginMutation.mutate(
-      { phone: stripPhoneToDigits(phone), name, storeId: Number(storeId) },
+      {
+        phone: stripPhoneToDigits(phone),
+        name,
+        ...(storeId && { storeId: Number(storeId) }),
+      },
       {
         onSuccess: () => {
           if (storeId) saveOriginStoreId(storeId);
@@ -64,7 +68,7 @@ export function CustomerLoginForm() {
     <div className="h-full p-6 pt-12 flex flex-col bg-white">
       <div className="flex items-center mb-6 -ml-2">
         <button
-          onClick={() => customerNavigate('/')}
+          onClick={() => navigate(-1)}
           className="p-2 text-kkookk-steel"
           aria-label="뒤로 가기"
         >
@@ -116,6 +120,13 @@ export function CustomerLoginForm() {
         >
           지갑 열기
         </Button>
+
+        {/* 직접 로그인 시에만 표시되는 안내 문구 */}
+        {!storeId && (
+          <p className="mt-4 text-xs text-center text-gray-500">
+            처음 방문하시나요? 가게에서 QR 코드를 스캔하여 시작하세요
+          </p>
+        )}
       </form>
     </div>
   );

--- a/frontend/src/features/landing/components/LandingHeader.tsx
+++ b/frontend/src/features/landing/components/LandingHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * LandingHeader
- * 랜딩 페이지 헤더 - 로고 + 문의하기 CTA
+ * 랜딩 페이지 헤더 - 로고 + 로그인 CTA
  */
 
 import { Link } from "react-router-dom";
@@ -19,9 +19,11 @@ export function LandingHeader() {
         </Link>
 
         {/* CTA */}
-        <button className="flex items-center h-10 px-5 py-2.5 font-semibold text-kkookk-orange-500 transition-all border-2 border-kkookk-orange-500 rounded-lg hover:bg-kkookk-orange-50">
-          문의하기
-        </button>
+        <Link to="/funnel">
+          <button className="flex items-center h-10 px-5 py-2.5 font-semibold text-kkookk-orange-500 transition-all border-2 border-kkookk-orange-500 rounded-lg hover:bg-kkookk-orange-50">
+            로그인
+          </button>
+        </Link>
       </div>
     </header>
   );

--- a/frontend/src/pages/RoleSelectionPage.tsx
+++ b/frontend/src/pages/RoleSelectionPage.tsx
@@ -1,0 +1,70 @@
+/**
+ * RoleSelectionPage
+ * 역할 선택 페이지 - 고객 vs 사장님 로그인 선택
+ */
+
+import { useNavigate } from "react-router-dom";
+import { User, Store } from "lucide-react";
+
+export function RoleSelectionPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-3xl w-full space-y-8">
+        {/* Header */}
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-gray-900">
+            꾸욱에 오신 것을 환영합니다
+          </h1>
+        </div>
+
+        {/* Role Selection Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Customer Card */}
+          <button
+            onClick={() => navigate("/customer/login")}
+            className="group p-8 bg-white border-2 border-gray-200 rounded-2xl hover:border-kkookk-orange-500 hover:shadow-lg transition-all duration-300 text-left"
+          >
+            <div className="flex flex-col items-center text-center space-y-4">
+              <div className="w-20 h-20 bg-transparent rounded-full flex items-center justify-center group-hover:bg-kkookk-orange-100 transition-colors duration-300">
+                <User className="w-10 h-10 text-kkookk-orange-500" />
+              </div>
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                  고객으로 시작
+                </h2>
+                <p className="text-gray-600">
+                  내 지갑을 확인하고 스탬프를 적립하세요
+                </p>
+              </div>
+            </div>
+          </button>
+
+          {/* Owner Card */}
+          <button
+            onClick={() => navigate("/owner/login")}
+            className="group p-8 bg-white border-2 border-gray-200 rounded-2xl hover:border-kkookk-indigo-500 hover:shadow-lg transition-all duration-300 text-left"
+          >
+            <div className="flex flex-col items-center text-center space-y-4">
+              <div className="w-20 h-20 bg-transparent rounded-full flex items-center justify-center group-hover:bg-kkookk-indigo-100 transition-colors duration-300">
+                <Store className="w-10 h-10 text-kkookk-indigo-500" />
+              </div>
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                  사장님으로 시작
+                </h2>
+                <p className="text-gray-600">
+                  매장을 관리하고 고객을 확인하세요
+                </p>
+              </div>
+            </div>
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+export default RoleSelectionPage;

--- a/frontend/src/pages/customer/DirectCustomerLoginPage.tsx
+++ b/frontend/src/pages/customer/DirectCustomerLoginPage.tsx
@@ -1,0 +1,13 @@
+/**
+ * DirectCustomerLoginPage
+ * 직접 고객 로그인 페이지 (storeId 없이 진입)
+ * 기존 CustomerLoginForm과 동일한 UI 사용
+ */
+
+import { CustomerLoginForm } from "@/features/auth/components/CustomerLoginForm";
+
+export function DirectCustomerLoginPage() {
+  return <CustomerLoginForm />;
+}
+
+export default DirectCustomerLoginPage;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -99,7 +99,7 @@ export interface WalletRegisterResponse {
 export interface WalletLoginRequest {
   phone: string;
   name: string;
-  storeId: number;
+  storeId?: number;
 }
 
 export interface WalletLoginStampCard {


### PR DESCRIPTION
## 🔗 관련 이슈

Close #137 

## 📌 작업 내용 요약
랜딩 페이지에서 QR 코드 없이도 고객이 직접 로그인할 수 있는 플로우(헤더 우상단 "로그인" 버튼 추가)를 추가했습니다.
기존에는 매장 QR 스캔을 통해서만 접근 가능했으나, 이제 웹에서 바로 내 지갑에 접근할 수 있습니다.

## 🚀 변경 사항
- 매장 ID를 필수에서 선택으로 변경
- 매장 QR 찍고 로그인: 해당 매장 카드를 맨 위에 표시
- 랜딩에서 직접 로그인: 모든 카드를 최근 적립한 순서로 표시