### PR TITLE
단색 StampCard에 KKOOKK 로고 워터마크 추가

### DIFF
--- a/frontend/src/features/landing/components/StampCardPreview.tsx
+++ b/frontend/src/features/landing/components/StampCardPreview.tsx
@@ -72,11 +72,22 @@ export function StampCardPreview({
         </div>
       </div>
 
-      {/* 배경 아이콘 */}
-      <Coffee
-        className="absolute w-24 h-24 transform -right-2 -bottom-3 text-white/8 rotate-12"
-        strokeWidth={0.8}
-      />
+      {/* 배경 장식 요소 */}
+      <>
+        {/* KKOOKK 텍스트 로고 - 왼쪽 상단 */}
+        <img
+          src="/logo/logo_text_customer.png"
+          alt=""
+          aria-hidden="true"
+          className="absolute -left-8 -top-8 opacity-[0.08] w-48 h-48 object-contain"
+          style={{ filter: 'brightness(0) invert(1)' }}
+        />
+        {/* 배경 아이콘 - 오른쪽 하단 */}
+        <Coffee
+          className="absolute w-24 h-24 transform -right-2 -bottom-3 text-white/8 rotate-12"
+          strokeWidth={0.8}
+        />
+      </>
 
       {/* 장식 요소 */}
       <div className="absolute -bottom-6 -right-6 w-24 h-24 rounded-full bg-kkookk-orange-500/5 blur-2xl" />

--- a/frontend/src/features/wallet/components/StampCardFront.tsx
+++ b/frontend/src/features/wallet/components/StampCardFront.tsx
@@ -5,79 +5,86 @@
  * backfaceVisibility는 부모(캐러셀)에서 처리
  */
 
-import { cn } from '@/lib/utils'
-import type { StampCard } from '@/types/domain'
+import { cn } from "@/lib/utils";
+import type { StampCard } from "@/types/domain";
 
 interface StampCardFrontProps {
-    card: StampCard
-    className?: string
+  card: StampCard;
+  className?: string;
 }
 
 export function StampCardFront({ card, className }: StampCardFrontProps) {
-    const hasBackgroundImage = !!card.backgroundImage
-    const bgGradient =
-        card.bgGradient || 'from-[var(--color-kkookk-orange-500)] to-[#E04F00]'
+  const hasBackgroundImage = !!card.backgroundImage;
+  const bgGradient =
+    card.bgGradient || "from-[var(--color-kkookk-orange-500)] to-[#E04F00]";
 
-    return (
-        <div
-            className={cn(
-                'w-full aspect-[1.58/1] rounded-2xl overflow-hidden relative',
-                'select-none',
-                !hasBackgroundImage && 'bg-linear-to-br',
-                !hasBackgroundImage && bgGradient,
-                className,
-            )}
-            style={
-                hasBackgroundImage
-                    ? {
-                          backgroundImage: `url(${card.backgroundImage})`,
-                          backgroundSize: 'cover',
-                          backgroundPosition: 'center',
-                      }
-                    : undefined
+  return (
+    <div
+      className={cn(
+        "w-full aspect-[1.58/1] rounded-2xl overflow-hidden relative",
+        "select-none",
+        !hasBackgroundImage && "bg-linear-to-br",
+        !hasBackgroundImage && bgGradient,
+        className,
+      )}
+      style={
+        hasBackgroundImage
+          ? {
+              backgroundImage: `url(${card.backgroundImage})`,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
             }
-        >
-            {/* 이미지형 글래스 오버레이 */}
-            {hasBackgroundImage && (
-                <div className="absolute inset-0 bg-black/10" />
-            )}
+          : undefined
+      }
+    >
+      {/* 이미지형 글래스 오버레이 */}
+      {hasBackgroundImage && <div className="absolute inset-0 bg-black/10" />}
 
-            {/* COLOR 타입 장식 요소 */}
-            {!hasBackgroundImage && (
-                <>
-                    {/* 상단 대각선 라이트 */}
-                    <div
-                        className="absolute -top-20 -right-20 w-60 h-60 rounded-full opacity-[0.08]"
-                        style={{
-                            background: 'radial-gradient(circle, white 0%, transparent 70%)',
-                        }}
-                    />
+      {/* COLOR 타입 장식 요소 */}
+      {!hasBackgroundImage && (
+        <>
+          {/* 상단 대각선 라이트 */}
+          <div
+            className="absolute -top-20 -right-20 w-60 h-60 rounded-full opacity-[0.08]"
+            style={{
+              background: "radial-gradient(circle, white 0%, transparent 70%)",
+            }}
+          />
 
-                    {/* 고양이 장식 아이콘 */}
-                    <img
-                        src="/image/cat_pace.png"
-                        alt=""
-                        aria-hidden="true"
-                        className="absolute -right-8 -bottom-8 opacity-[0.07] w-52 h-52 object-cover -rotate-12"
-                    />
+          {/* KKOOKK 텍스트 로고 - 왼쪽 상단 */}
+          <img
+            src="/logo/logo_text_customer.png"
+            alt=""
+            aria-hidden="true"
+            className="absolute -left-4 -top-22 opacity-[0.07] w-68 h-68 object-contain"
+            style={{ filter: "brightness(0) invert(1)" }}
+          />
 
-                    {/* 하단 그라데이션 깊이감 */}
-                    <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-t from-black/8 to-transparent" />
-                </>
-            )}
+          {/* 고양이 장식 아이콘 */}
+          <img
+            src="/image/cat_pace.png"
+            alt=""
+            aria-hidden="true"
+            className="absolute -right-8 -bottom-8 opacity-[0.07] w-52 h-52 object-cover -rotate-12"
+          />
 
-            {/* 미세한 노이즈 텍스처 오버레이 */}
-            <div
-                className="absolute inset-0 opacity-[0.03] mix-blend-overlay pointer-events-none"
-                style={{
-                    backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
-                }}
-            />
+          {/* 하단 그라데이션 깊이감 */}
+          <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-t from-black/8 to-transparent" />
+        </>
+      )}
 
-            {/* 인너 보더 하이라이트 */}
-            <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/15 pointer-events-none" />
-        </div>
-    )
+      {/* 미세한 노이즈 텍스처 오버레이 */}
+      <div
+        className="absolute inset-0 opacity-[0.03] mix-blend-overlay pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+        }}
+      />
+
+      {/* 인너 보더 하이라이트 */}
+      <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/15 pointer-events-none" />
+    </div>
+  );
 }
 
-export default StampCardFront
+export default StampCardFront;

--- a/frontend/src/features/wallet/components/StampCardItem.tsx
+++ b/frontend/src/features/wallet/components/StampCardItem.tsx
@@ -71,11 +71,23 @@ export function StampCardItem({
 
       {/* 배경 아이콘 (COLOR 타입만) */}
       {!hasBackgroundImage && (
-        <img
-          src="/image/cat_pace.png"
-          alt="Background"
-          className="absolute -right-12 -bottom-12 opacity-10 w-64 h-64 object-cover transform -rotate-12"
-        />
+        <>
+          {/* KKOOKK 텍스트 로고 - 왼쪽 상단 */}
+          <img
+            src="/logo/logo_text_customer.png"
+            alt=""
+            aria-hidden="true"
+            className="absolute -left-20 -top-20 opacity-10 w-80 h-80 object-contain"
+            style={{ filter: 'brightness(0) invert(1)' }}
+          />
+          {/* 고양이 장식 아이콘 - 오른쪽 하단 */}
+          <img
+            src="/image/cat_pace.png"
+            alt=""
+            aria-hidden="true"
+            className="absolute -right-12 -bottom-12 opacity-10 w-64 h-64 object-cover transform -rotate-12"
+          />
+        </>
       )}
 
       {/* 푸터 */}


### PR DESCRIPTION
## 🔗 관련 이슈
Close #145 

## 📌 작업 내용 요약
단색 StampCard가 밋밋하다는 피드백을 반영하여 왼쪽 상단에 KKOOKK 텍스트 로고를 워터마크로 추가했습니다.

## 🚀 변경 사항
- **StampCardFront, StampCardItem, StampCardPreview** 컴포넌트에 KKOOKK 로고 추가
- 왼쪽 상단에 배치하여 오른쪽 하단 고양이 장식과 대칭 구조 형성
 - COLOR 타입 카드에만 표시 (이미지형 카드는 기존 유지)

## 📎 참고 자료
<img width="401" height="295" alt="스크린샷 2026-02-18 오후 11 00 14" src="https://github.com/user-attachments/assets/8a544c5f-73ae-4e1f-b563-7c56c049edd2" />
