### PR TITLE
QA : 사장님 백오피스 회원가입 라우트 변경 

### DIFF
--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -32,6 +32,7 @@ import { AdminStoreListPage } from "@/pages/admin/AdminStoreListPage";
 
 // 사장님 페이지
 import { OwnerLoginPage } from "@/features/auth/pages/OwnerLoginPage";
+import { OwnerSignupPage } from "@/features/auth/pages/OwnerSignupPage";
 import {
   StampCardCreatePage,
   StampCardEditPage,
@@ -119,6 +120,12 @@ export const router = createBrowserRouter([
   {
     path: "/owner/login",
     element: <OwnerLoginPage />,
+  },
+
+  // 사장님 회원가입 (레이아웃 없음)
+  {
+    path: "/owner/signup",
+    element: <OwnerSignupPage />,
   },
 
   // 사장님 라우트

--- a/frontend/src/features/auth/pages/OwnerLoginPage.tsx
+++ b/frontend/src/features/auth/pages/OwnerLoginPage.tsx
@@ -7,12 +7,9 @@ import { ChevronLeft } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { LoginForm } from "../components/LoginForm";
-import { PhoneVerification } from "../components/PhoneVerification";
-import { SignupForm } from "../components/SignupForm";
-import { useOwnerLogin, useOwnerSignup, useOtpRequest, useOtpVerify } from "../hooks/useAuth";
+import { useOwnerLogin } from "../hooks/useAuth";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { kkookkToast } from "@/components/ui/Toast";
-import type { AuthMode } from "../types";
 
 interface OwnerLoginPageProps {
   title?: string;
@@ -34,11 +31,8 @@ export function OwnerLoginPage({
   const navigate = useNavigate();
   const { refreshAuthState } = useAuth();
 
-  // API Hooks
   const ownerLogin = useOwnerLogin();
-  const ownerSignup = useOwnerSignup();
-  const otpRequest = useOtpRequest();
-  const otpVerify = useOtpVerify();
+  const [errorMessage, setErrorMessage] = useState("");
 
   const handleLoginSuccess = () => {
     refreshAuthState();
@@ -56,27 +50,9 @@ export function OwnerLoginPage({
       navigate("/simulation");
     }
   };
-  const [authMode, setAuthMode] = useState<AuthMode>("login");
-  const [phone, setPhone] = useState("");
-  const [signupData, setSignupData] = useState<{
-    name: string;
-    phone: string;
-    email: string;
-    password: string;
-  } | null>(null);
-  const [errorMessage, setErrorMessage] = useState("");
-  const [successMessage, setSuccessMessage] = useState("");
-  const [devOtpCode, setDevOtpCode] = useState("");
-
-  const isLoading = ownerLogin.isPending || ownerSignup.isPending || otpRequest.isPending || otpVerify.isPending;
-
-  const clearMessages = () => {
-    setErrorMessage("");
-    setSuccessMessage("");
-  };
 
   const handleLogin = (email: string, password: string) => {
-    clearMessages();
+    setErrorMessage("");
     ownerLogin.mutate(
       { email, password },
       {
@@ -92,98 +68,6 @@ export function OwnerLoginPage({
     );
   };
 
-  const handleSignup = (data: {
-    name: string;
-    phone: string;
-    email: string;
-    password: string;
-  }) => {
-    clearMessages();
-    setPhone(data.phone);
-    setSignupData(data);
-
-    // OTP 요청
-    otpRequest.mutate(
-      { phone: data.phone },
-      {
-        onSuccess: (response) => {
-          setAuthMode("verify");
-          if (response.devOtpCode) {
-            setDevOtpCode(response.devOtpCode);
-          }
-        },
-        onError: () => {
-          setErrorMessage("인증번호 발송 실패. 잠시 후 다시 시도해주세요.");
-        },
-      }
-    );
-  };
-
-  const handleVerify = (code: string) => {
-    if (!signupData) return;
-    clearMessages();
-
-    otpVerify.mutate(
-      { phone, code },
-      {
-        onSuccess: (response) => {
-          if (response.verified) {
-            // OTP 인증 성공 후 회원가입 진행
-            ownerSignup.mutate(
-              {
-                email: signupData.email,
-                password: signupData.password,
-                name: signupData.name,
-                phoneNumber: signupData.phone,
-              },
-              {
-                onSuccess: () => {
-                  kkookkToast.success("회원가입이 완료되었습니다", { description: "로그인해주세요." });
-                  setSuccessMessage("회원가입이 완료되었습니다. 로그인해주세요.");
-                  setDevOtpCode("");
-                  setAuthMode("login");
-                  setSignupData(null);
-                },
-                onError: () => {
-                  setErrorMessage("회원가입 실패. 이미 등록된 이메일일 수 있습니다.");
-                },
-              }
-            );
-          } else {
-            setErrorMessage("인증번호가 일치하지 않습니다.");
-          }
-        },
-        onError: () => {
-          setErrorMessage("인증 실패. 인증번호를 확인해주세요.");
-        },
-      }
-    );
-  };
-
-  const handleResend = () => {
-    clearMessages();
-    otpRequest.mutate(
-      { phone },
-      {
-        onSuccess: (response) => {
-          if (response.devOtpCode) {
-            setDevOtpCode(response.devOtpCode);
-          }
-          setSuccessMessage(`인증번호가 ${phone}로 재발송되었습니다.`);
-        },
-        onError: () => {
-          setErrorMessage("인증번호 재발송 실패. 1분 후 다시 시도해주세요.");
-        },
-      }
-    );
-  };
-
-  const handleSwitchMode = (mode: AuthMode) => {
-    clearMessages();
-    setDevOtpCode("");
-    setAuthMode(mode);
-  };
-
   return (
     <div
       className={`flex flex-col items-center justify-center min-h-screen p-6 ${isTabletMode ? "w-full" : ""}`}
@@ -196,46 +80,12 @@ export function OwnerLoginPage({
           {subtitle && <p className="text-sm text-kkookk-steel">{subtitle}</p>}
         </div>
 
-        {errorMessage && authMode === "signup" && (
-          <div className="mb-4 p-3 rounded-xl bg-red-50 text-red-600 text-sm text-center">
-            {errorMessage}
-          </div>
-        )}
-        {successMessage && authMode !== "verify" && (
-          <div className="mb-4 p-3 rounded-xl bg-emerald-50 text-emerald-600 text-sm text-center">
-            {successMessage}
-          </div>
-        )}
-
-        {authMode === "login" && (
-          <LoginForm
-            onSubmit={handleLogin}
-            onSwitchToSignup={() => handleSwitchMode("signup")}
-            isLoading={isLoading}
-            error={errorMessage}
-          />
-        )}
-
-        {authMode === "signup" && (
-          <SignupForm
-            onSubmit={handleSignup}
-            onSwitchToLogin={() => handleSwitchMode("login")}
-            isLoading={isLoading}
-          />
-        )}
-
-        {authMode === "verify" && (
-          <PhoneVerification
-            phone={phone}
-            devOtpCode={devOtpCode}
-            onVerify={handleVerify}
-            onResend={handleResend}
-            onBack={() => handleSwitchMode("signup")}
-            isLoading={isLoading}
-            error={errorMessage}
-            success={successMessage}
-          />
-        )}
+        <LoginForm
+          onSubmit={handleLogin}
+          onSwitchToSignup={() => navigate("/owner/signup")}
+          isLoading={ownerLogin.isPending}
+          error={errorMessage}
+        />
       </div>
 
       <button

--- a/frontend/src/features/auth/pages/OwnerSignupPage.tsx
+++ b/frontend/src/features/auth/pages/OwnerSignupPage.tsx
@@ -1,0 +1,172 @@
+/**
+ * OwnerSignupPage
+ * 사장님 회원가입 페이지 (회원가입 폼 + OTP 인증)
+ */
+
+import { ChevronLeft } from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { PhoneVerification } from "../components/PhoneVerification";
+import { SignupForm } from "../components/SignupForm";
+import { useOwnerSignup, useOtpRequest, useOtpVerify } from "../hooks/useAuth";
+import { kkookkToast } from "@/components/ui/Toast";
+
+type SignupStep = "form" | "verify";
+
+export function OwnerSignupPage() {
+  const navigate = useNavigate();
+
+  const ownerSignup = useOwnerSignup();
+  const otpRequest = useOtpRequest();
+  const otpVerify = useOtpVerify();
+
+  const [step, setStep] = useState<SignupStep>("form");
+  const [phone, setPhone] = useState("");
+  const [signupData, setSignupData] = useState<{
+    name: string;
+    phone: string;
+    email: string;
+    password: string;
+  } | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [devOtpCode, setDevOtpCode] = useState("");
+
+  const isLoading = ownerSignup.isPending || otpRequest.isPending || otpVerify.isPending;
+
+  const clearMessages = () => {
+    setErrorMessage("");
+    setSuccessMessage("");
+  };
+
+  const handleSignup = (data: {
+    name: string;
+    phone: string;
+    email: string;
+    password: string;
+  }) => {
+    clearMessages();
+    setPhone(data.phone);
+    setSignupData(data);
+
+    otpRequest.mutate(
+      { phone: data.phone },
+      {
+        onSuccess: (response) => {
+          setStep("verify");
+          if (response.devOtpCode) {
+            setDevOtpCode(response.devOtpCode);
+          }
+        },
+        onError: () => {
+          setErrorMessage("인증번호 발송 실패. 잠시 후 다시 시도해주세요.");
+        },
+      }
+    );
+  };
+
+  const handleVerify = (code: string) => {
+    if (!signupData) return;
+    clearMessages();
+
+    otpVerify.mutate(
+      { phone, code },
+      {
+        onSuccess: (response) => {
+          if (response.verified) {
+            ownerSignup.mutate(
+              {
+                email: signupData.email,
+                password: signupData.password,
+                name: signupData.name,
+                phoneNumber: signupData.phone,
+              },
+              {
+                onSuccess: () => {
+                  kkookkToast.success("회원가입이 완료되었습니다", { description: "로그인해주세요." });
+                  navigate("/owner/login");
+                },
+                onError: () => {
+                  setErrorMessage("회원가입 실패. 이미 등록된 이메일일 수 있습니다.");
+                },
+              }
+            );
+          } else {
+            setErrorMessage("인증번호가 일치하지 않습니다.");
+          }
+        },
+        onError: () => {
+          setErrorMessage("인증 실패. 인증번호를 확인해주세요.");
+        },
+      }
+    );
+  };
+
+  const handleResend = () => {
+    clearMessages();
+    otpRequest.mutate(
+      { phone },
+      {
+        onSuccess: (response) => {
+          if (response.devOtpCode) {
+            setDevOtpCode(response.devOtpCode);
+          }
+          setSuccessMessage(`인증번호가 ${phone}로 재발송되었습니다.`);
+        },
+        onError: () => {
+          setErrorMessage("인증번호 재발송 실패. 1분 후 다시 시도해주세요.");
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-6">
+      <div className="bg-white rounded-3xl shadow-xl p-8 w-full max-w-md border border-slate-200">
+        <div className="mb-8 text-center">
+          <h2 className="mb-2 text-2xl font-bold text-kkookk-navy">사장님 회원가입</h2>
+        </div>
+
+        {errorMessage && step === "form" && (
+          <div className="mb-4 p-3 rounded-xl bg-red-50 text-red-600 text-sm text-center">
+            {errorMessage}
+          </div>
+        )}
+
+        {step === "form" && (
+          <SignupForm
+            onSubmit={handleSignup}
+            onSwitchToLogin={() => navigate("/owner/login")}
+            isLoading={isLoading}
+          />
+        )}
+
+        {step === "verify" && (
+          <PhoneVerification
+            phone={phone}
+            devOtpCode={devOtpCode}
+            onVerify={handleVerify}
+            onResend={handleResend}
+            onBack={() => {
+              clearMessages();
+              setDevOtpCode("");
+              setStep("form");
+            }}
+            isLoading={isLoading}
+            error={errorMessage}
+            success={successMessage}
+          />
+        )}
+      </div>
+
+      <button
+        onClick={() => navigate("/simulation")}
+        className="flex items-center gap-1 mt-4 text-sm text-kkookk-steel hover:text-kkookk-indigo"
+      >
+        <ChevronLeft size={16} /> 초기 화면으로
+      </button>
+    </div>
+  );
+}
+
+export default OwnerSignupPage;

--- a/frontend/src/features/auth/pages/index.ts
+++ b/frontend/src/features/auth/pages/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './OwnerLoginPage';
+export * from './OwnerSignupPage';


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #147 

## 📌 작업 내용 요약
  사장님 로그인/회원가입 페이지를 하나의 URL(/owner/login)에서 조건부 렌더링하던 구조를 별도 라우트로 분리        
          
## 🚀 변경 사항
  - /owner/login — 로그인 전용 (회원가입/OTP 로직 제거)                                                                     
  - /owner/signup — 회원가입 + OTP 인증 전용 (새 페이지)
  - 로그인 ↔ 회원가입 전환 시 navigate()로 페이지 이동
  - 회원가입 완료 시 /owner/login으로 자동 이동

----
### AFTER
- 뒤로가기 가능.
- 링크로 특정 화면 이동 가능. (login, signup)
- 새로 고침해도 초기화되지 않음. 


## 📎 참고 자료 
<img width="943" height="858" alt="스크린샷 2026-02-19 오전 2 25 28" src="https://github.com/user-attachments/assets/88d8dd3e-b780-4e4c-8bd9-7e71abb40320" />