### PR TITLE
고객 PWA BottomNavigationBar 추가 및 OTP 모달 개선

### DIFF
--- a/frontend/src/app/layouts/CustomerLayout.tsx
+++ b/frontend/src/app/layouts/CustomerLayout.tsx
@@ -6,62 +6,122 @@
  * Post-login: /customer/* (sessionStorage storeId)
  */
 
-import { useState } from 'react';
-import { Outlet, useNavigate, useParams } from 'react-router-dom';
-import { MobileFrame } from '@/components/layout/MobileFrame';
-import { useAuth } from '@/app/providers/AuthProvider';
-import { clearOriginStoreId } from '@/hooks/useCustomerNavigate';
-import { ScrollToTop } from '@/components/shared/ScrollToTop';
+import { useState } from 'react'
+import { Outlet, useNavigate, useParams, useLocation } from 'react-router-dom'
+import { MobileFrame } from '@/components/layout/MobileFrame'
+import { PrivacyPolicyModal } from '@/components/shared/PrivacyPolicyModal'
+import { useAuth } from '@/app/providers/AuthProvider'
+import { clearOriginStoreId } from '@/hooks/useCustomerNavigate'
+import { isStepUpValid } from '@/lib/api/tokenManager'
+import { ScrollToTop } from '@/components/shared/ScrollToTop'
+import { getUserInfo } from '@/lib/api/tokenManager'
 
 export function CustomerLayout() {
-  const navigate = useNavigate();
-  const { storeId: urlStoreId } = useParams<{ storeId: string }>();
-  const { logout } = useAuth();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [currentStoreId, setCurrentStoreId] = useState<number | undefined>(undefined);
+    const navigate = useNavigate()
+    const location = useLocation()
+    const { storeId: urlStoreId } = useParams<{ storeId: string }>()
+    const { logout } = useAuth()
 
-  // Pre-login: /stores/:storeId/customer, Post-login: /customer
-  const base = urlStoreId ? `/stores/${urlStoreId}/customer` : '/customer';
+    const [isMenuOpen, setIsMenuOpen] = useState(false)
+    const [currentStoreId, setCurrentStoreId] = useState<number | undefined>(undefined)
+    const [isOtpModalOpen, setIsOtpModalOpen] = useState(false)
+    const [afterOtpCallback, setAfterOtpCallback] = useState<(() => void) | null>(null)
+    const [isPrivacyModalOpen, setIsPrivacyModalOpen] = useState(false)
+    const [isStepUpVerified, setIsStepUpVerified] = useState(isStepUpValid())
 
-  const handleMenuItemClick = (screen: string) => {
-    setIsMenuOpen(false);
-    switch (screen) {
-      case 'history': {
-        const query = currentStoreId ? `?storeId=${currentStoreId}` : '';
-        navigate(`${base}/history${query}`);
-        break;
-      }
-      case 'rewardBox':
-        navigate(`${base}/redeems`);
-        break;
-      case 'migrationList':
-        navigate(`${base}/migrations`);
-        break;
-      case 'settings':
-        navigate(`${base}/settings`);
-        break;
-      default:
-        navigate(`${base}/wallet`);
+    // Pre-login: /stores/:storeId/customer, Post-login: /customer
+    const base = urlStoreId ? `/stores/${urlStoreId}/customer` : '/customer'
+
+    const userInfo = getUserInfo()
+    const userName = userInfo?.name ? `${userInfo.name}님` : '김고객님'
+
+    const navigateToTab = (tab: string) => {
+        switch (tab) {
+            case 'history': {
+                const query = currentStoreId ? `?storeId=${currentStoreId}` : ''
+                navigate(`${base}/history${query}`)
+                break
+            }
+            case 'rewardBox':
+                navigate(`${base}/redeems`)
+                break
+            case 'migrationList':
+                navigate(`${base}/migrations`)
+                break
+            default:
+                navigate(`${base}/wallet`)
+        }
     }
-  };
 
-  const handleLogout = () => {
-    clearOriginStoreId();
-    logout();
-    navigate('/');
-  };
+    const openOtpModal = (callback?: () => void) => {
+        setAfterOtpCallback(() => callback ?? null)
+        setIsOtpModalOpen(true)
+    }
 
-  return (
-    <MobileFrame
-      isMenuOpen={isMenuOpen}
-      onMenuClose={() => setIsMenuOpen(false)}
-      onMenuItemClick={handleMenuItemClick}
-      onLogout={handleLogout}
-    >
-      <ScrollToTop />
-      <Outlet context={{ setIsMenuOpen, setCurrentStoreId }} />
-    </MobileFrame>
-  );
+    const handleBottomNavClick = (tab: string) => {
+        if (tab === 'wallet') {
+            navigate(`${base}/wallet`)
+            return
+        }
+        const requiresStepUp = ['history', 'rewardBox', 'migrationList'].includes(tab)
+        if (requiresStepUp && !isStepUpValid()) {
+            openOtpModal(() => navigateToTab(tab))
+        } else {
+            navigateToTab(tab)
+        }
+    }
+
+    const handleVerifyIdentity = () => {
+        setIsMenuOpen(false)
+        if (!isStepUpValid()) {
+            openOtpModal()
+        }
+    }
+
+    const handlePrivacyPolicy = () => {
+        setIsMenuOpen(false)
+        setIsPrivacyModalOpen(true)
+    }
+
+    const handleOtpVerified = () => {
+        setIsStepUpVerified(true)
+        setIsOtpModalOpen(false)
+        afterOtpCallback?.()
+        setAfterOtpCallback(null)
+    }
+
+    const handleLogout = () => {
+        clearOriginStoreId()
+        logout()
+        navigate('/')
+    }
+
+    return (
+        <>
+            <MobileFrame
+                isMenuOpen={isMenuOpen}
+                onMenuClose={() => setIsMenuOpen(false)}
+                onVerifyIdentity={handleVerifyIdentity}
+                onPrivacyPolicy={handlePrivacyPolicy}
+                onLogout={handleLogout}
+                userName={userName}
+                showBottomNav={!urlStoreId && !location.pathname.includes('/stamp') && !location.pathname.endsWith('/use')}
+                onBottomNavClick={handleBottomNavClick}
+                isStepUpVerified={isStepUpVerified}
+                isOtpModalOpen={isOtpModalOpen}
+                onOtpModalChange={setIsOtpModalOpen}
+                onOtpVerified={handleOtpVerified}
+            >
+                <ScrollToTop />
+                <Outlet context={{ setIsMenuOpen, setCurrentStoreId }} />
+            </MobileFrame>
+
+            <PrivacyPolicyModal
+                open={isPrivacyModalOpen}
+                onOpenChange={setIsPrivacyModalOpen}
+            />
+        </>
+    )
 }
 
-export default CustomerLayout;
+export default CustomerLayout

--- a/frontend/src/components/layout/BottomNavigationBar.tsx
+++ b/frontend/src/components/layout/BottomNavigationBar.tsx
@@ -1,0 +1,76 @@
+/**
+ * BottomNavigationBar 컴포넌트
+ * 고객 PWA 하단 탭 네비게이션 (내 지갑 / 이력 / 리워드 / 전환)
+ */
+
+import { useLocation } from 'react-router-dom'
+import { Wallet, History, Gift, FileText } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type TabKey = 'wallet' | 'history' | 'rewardBox' | 'migrationList'
+
+interface Tab {
+    key: TabKey
+    label: string
+    icon: React.ElementType
+    pathSegment: string
+}
+
+const TABS: Tab[] = [
+    { key: 'wallet', label: '내 지갑', icon: Wallet, pathSegment: '/wallet' },
+    { key: 'history', label: '이력', icon: History, pathSegment: '/history' },
+    { key: 'rewardBox', label: '리워드', icon: Gift, pathSegment: '/redeems' },
+    { key: 'migrationList', label: '전환', icon: FileText, pathSegment: '/migrations' },
+]
+
+interface BottomNavigationBarProps {
+    onTabClick: (tab: TabKey) => void
+}
+
+export function BottomNavigationBar({ onTabClick }: BottomNavigationBarProps) {
+    const { pathname } = useLocation()
+
+    const getActiveTab = (): TabKey => {
+        if (pathname.includes('/history')) return 'history'
+        if (pathname.includes('/redeems')) return 'rewardBox'
+        if (pathname.includes('/migrations')) return 'migrationList'
+        return 'wallet'
+    }
+
+    const activeTab = getActiveTab()
+
+    return (
+        <nav
+            className="shrink-0 flex items-stretch bg-white border-t border-slate-100 z-20"
+            aria-label="하단 탭 네비게이션"
+        >
+            {TABS.map(({ key, label, icon: Icon }) => {
+                const isActive = activeTab === key
+                return (
+                    <button
+                        key={key}
+                        onClick={() => onTabClick(key)}
+                        className={cn(
+                            'flex-1 flex flex-col items-center justify-center gap-1 py-3 transition-colors',
+                            isActive
+                                ? 'text-kkookk-orange-500'
+                                : 'text-kkookk-steel hover:text-kkookk-navy'
+                        )}
+                        aria-label={label}
+                        aria-current={isActive ? 'page' : undefined}
+                    >
+                        <Icon
+                            size={22}
+                            strokeWidth={isActive ? 2.5 : 1.8}
+                        />
+                        <span className={cn('text-[11px] font-medium', isActive && 'font-bold')}>
+                            {label}
+                        </span>
+                    </button>
+                )
+            })}
+        </nav>
+    )
+}
+
+export default BottomNavigationBar

--- a/frontend/src/components/layout/MobileFrame.tsx
+++ b/frontend/src/components/layout/MobileFrame.tsx
@@ -1,144 +1,170 @@
 /**
  * MobileFrame 컴포넌트
  * 고객 PWA를 위한 풀스크린 웹앱 컨테이너
- * 슬라이드 아웃 메뉴 포함
+ * 옵션 사이드바 + BottomNavigationBar + OTP 모달 포함
  */
 
-import type { ReactNode } from 'react';
-import { X } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { MenuLink } from '@/components/shared/MenuLink';
-import {
-  History,
-  Gift,
-  FileText,
-  Settings,
-  LogOut,
-} from 'lucide-react';
+import type { ReactNode } from 'react'
+import { X, ShieldCheck, BookOpen, Info, LogOut } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { MenuLink } from '@/components/shared/MenuLink'
+import { BottomNavigationBar } from '@/components/layout/BottomNavigationBar'
+import { OtpVerifyModal } from '@/components/shared/OtpVerifyModal'
 
 interface MobileFrameProps {
-  children: ReactNode;
-  isMenuOpen?: boolean;
-  onMenuClose?: () => void;
-  onMenuItemClick?: (screen: string) => void;
-  onLogout?: () => void;
-  userName?: string;
-  className?: string;
+    children: ReactNode
+    // 옵션 사이드바
+    isMenuOpen?: boolean
+    onMenuClose?: () => void
+    onVerifyIdentity?: () => void
+    onPrivacyPolicy?: () => void
+    onLogout?: () => void
+    userName?: string
+    // BottomNav
+    showBottomNav?: boolean
+    onBottomNavClick?: (tab: string) => void
+    // OTP Modal
+    isStepUpVerified?: boolean
+    isOtpModalOpen?: boolean
+    onOtpModalChange?: (open: boolean) => void
+    onOtpVerified?: () => void
+    className?: string
 }
 
 export function MobileFrame({
-  children,
-  isMenuOpen = false,
-  onMenuClose,
-  onMenuItemClick,
-  onLogout,
-  userName = '김고객님',
-  className,
+    children,
+    isMenuOpen = false,
+    onMenuClose,
+    onVerifyIdentity,
+    onPrivacyPolicy,
+    onLogout,
+    userName = '김고객님',
+    showBottomNav = false,
+    onBottomNavClick,
+    isStepUpVerified = false,
+    isOtpModalOpen = false,
+    onOtpModalChange,
+    onOtpVerified,
+    className,
 }: MobileFrameProps) {
-  return (
-    <div className="min-h-screen w-full bg-kkookk-sand flex justify-center">
-      <div
-        className={cn(
-          'w-full max-w-md min-h-screen bg-white flex flex-col relative overflow-hidden',
-          className
-        )}
-      >
-        {/* 메인 콘텐츠 영역 - 전체 높이 사용 */}
-        <main className="flex-1 flex flex-col no-scrollbar bg-white">
-          {children}
-        </main>
+    return (
+        <div className="h-dvh w-full bg-kkookk-sand flex justify-center">
+            <div
+                className={cn(
+                    'w-full max-w-md h-full bg-white flex flex-col relative overflow-hidden',
+                    className
+                )}
+            >
+                {/* 메인 콘텐츠 영역 */}
+                <main className="flex-1 min-h-0 flex flex-col no-scrollbar bg-white overflow-y-auto">
+                    {children}
+                </main>
 
-        {/* 슬라이드 아웃 메뉴 */}
-        <div
-          className={cn(
-            "absolute inset-0 z-50 flex justify-end transition-opacity duration-200",
-            isMenuOpen ? "pointer-events-auto" : "opacity-0 pointer-events-none"
-          )}
-        >
-          {/* 배경 오버레이 */}
-          <div
-            role="button"
-            tabIndex={0}
-            aria-label="메뉴 닫기"
-            className={cn(
-              "absolute inset-0 transition-all duration-200",
-              isMenuOpen ? "bg-kkookk-navy/20 backdrop-blur-sm" : "bg-transparent"
-            )}
-            onClick={onMenuClose}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onMenuClose?.();
-              }
-            }}
-          />
-          {/* 메뉴 패널 */}
-          <div
-            className={cn(
-              "relative w-[300px] max-w-[80vw] h-full bg-white shadow-2xl flex flex-col",
-              "transition-transform duration-300 ease-out",
-              isMenuOpen ? "translate-x-0" : "translate-x-full"
-            )}
-          >
-              {/* 메뉴 헤더 */}
-              <div className="p-6 pt-12 flex justify-between items-center border-b border-slate-100">
-                <span className="font-bold text-lg text-kkookk-navy">전체 메뉴</span>
-                <button
-                  onClick={onMenuClose}
-                  className="p-2 -mr-2 text-kkookk-steel hover:text-kkookk-navy hover:bg-slate-50 rounded-full transition-colors"
-                  aria-label="메뉴 닫기"
+                {/* 하단 탭 네비게이션 */}
+                {showBottomNav && onBottomNavClick && (
+                    <BottomNavigationBar onTabClick={(tab) => onBottomNavClick(tab)} />
+                )}
+
+                {/* OTP 인증 모달 */}
+                {onOtpVerified && onOtpModalChange && (
+                    <OtpVerifyModal
+                        open={isOtpModalOpen}
+                        onOpenChange={onOtpModalChange}
+                        onVerified={onOtpVerified}
+                    />
+                )}
+
+                {/* 옵션 사이드바 */}
+                <div
+                    className={cn(
+                        'absolute inset-0 z-50 flex justify-end transition-opacity duration-200',
+                        isMenuOpen ? 'pointer-events-auto' : 'opacity-0 pointer-events-none'
+                    )}
                 >
-                  <X size={24} />
-                </button>
-              </div>
+                    {/* 배경 오버레이 */}
+                    <div
+                        role="button"
+                        tabIndex={0}
+                        aria-label="메뉴 닫기"
+                        className={cn(
+                            'absolute inset-0 transition-all duration-200',
+                            isMenuOpen ? 'bg-kkookk-navy/20 backdrop-blur-sm' : 'bg-transparent'
+                        )}
+                        onClick={onMenuClose}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                onMenuClose?.()
+                            }
+                        }}
+                    />
 
-              {/* 메뉴 콘텐츠 */}
-              <div className="flex-1 overflow-y-auto no-scrollbar py-2">
-                {/* 사용자 정보 */}
-                <div className="px-6 py-4 mb-2">
-                  <p className="text-xs text-kkookk-steel mb-1">현재 계정</p>
-                  <p className="font-bold text-lg text-kkookk-navy">{userName}</p>
+                    {/* 옵션 패널 */}
+                    <div
+                        className={cn(
+                            'relative w-75 max-w-[80vw] h-full bg-white shadow-2xl flex flex-col',
+                            'transition-transform duration-300 ease-out',
+                            isMenuOpen ? 'translate-x-0' : 'translate-x-full'
+                        )}
+                    >
+                        {/* 헤더: 유저 이름 + X 버튼 */}
+                        <div className="p-6 pt-12 flex justify-between items-start border-b border-slate-100">
+                            <h2 className="font-bold text-xl text-kkookk-navy">{userName}</h2>
+                            <button
+                                onClick={onMenuClose}
+                                className="p-2 -mr-2 -mt-1 text-kkookk-steel hover:text-kkookk-navy hover:bg-slate-50 rounded-full transition-colors"
+                                aria-label="메뉴 닫기"
+                            >
+                                <X size={24} />
+                            </button>
+                        </div>
+
+                        {/* 옵션 목록 */}
+                        <div className="flex-1 overflow-y-auto no-scrollbar py-2">
+                            {isStepUpVerified ? (
+                                <div className="w-full flex items-center gap-4 px-6 py-4 cursor-default">
+                                    <ShieldCheck size={20} className="text-kkookk-orange-500 shrink-0" />
+                                    <span className="font-medium text-kkookk-orange-500">본인 인증</span>
+                                    <span className="ml-auto text-xs font-bold text-kkookk-orange-500 bg-orange-50 px-2 py-1 rounded-full">
+                                        인증됨
+                                    </span>
+                                </div>
+                            ) : (
+                                <MenuLink
+                                    icon={<ShieldCheck size={20} />}
+                                    label="본인 인증"
+                                    onClick={onVerifyIdentity ?? (() => {})}
+                                />
+                            )}
+                            <MenuLink
+                                icon={<BookOpen size={20} />}
+                                label="개인정보처리방침"
+                                onClick={onPrivacyPolicy}
+                            />
+                            <div className="flex items-center gap-3 px-6 py-4 text-slate-400">
+                                <Info size={20} />
+                                <span className="text-sm">
+                                    버전 정보{' '}
+                                    <span className="text-xs font-mono ml-1">v1.0.0</span>
+                                </span>
+                            </div>
+                        </div>
+
+                        {/* 로그아웃 */}
+                        <div className="p-6 border-t border-slate-100 bg-kkookk-sand/30">
+                            <button
+                                onClick={onLogout}
+                                className="flex items-center gap-3 w-full p-3 text-kkookk-steel hover:text-red-600 hover:bg-red-50 rounded-xl transition-colors"
+                            >
+                                <LogOut size={20} />
+                                <span className="font-medium text-sm">로그아웃 / 나가기</span>
+                            </button>
+                        </div>
+                    </div>
                 </div>
-
-                {/* 메뉴 링크들 */}
-                <MenuLink
-                  icon={<History size={20} />}
-                  label="스탬프/리워드 이력"
-                  onClick={() => onMenuItemClick?.('history')}
-                />
-                <MenuLink
-                  icon={<Gift size={20} />}
-                  label="리워드 보관함"
-                  onClick={() => onMenuItemClick?.('rewardBox')}
-                />
-                <MenuLink
-                  icon={<FileText size={20} />}
-                  label="종이 스탬프 전환"
-                  onClick={() => onMenuItemClick?.('migrationList')}
-                />
-                <MenuLink
-                  icon={<Settings size={20} />}
-                  label="설정"
-                  onClick={() => onMenuItemClick?.('settings')}
-                />
-              </div>
-
-              {/* 메뉴 푸터 */}
-              <div className="p-6 border-t border-slate-100 bg-kkookk-sand/30">
-                <button
-                  onClick={onLogout}
-                  className="flex items-center gap-3 w-full p-3 text-kkookk-steel hover:text-red-600 hover:bg-red-50 rounded-xl transition-colors"
-                >
-                  <LogOut size={20} />
-                  <span className="font-medium text-sm">로그아웃 / 나가기</span>
-                </button>
-              </div>
             </div>
-          </div>
-      </div>
-
-    </div>
-  );
+        </div>
+    )
 }
 
-export default MobileFrame;
+export default MobileFrame

--- a/frontend/src/components/shared/OtpVerifyModal.tsx
+++ b/frontend/src/components/shared/OtpVerifyModal.tsx
@@ -1,0 +1,29 @@
+/**
+ * OtpVerifyModal 컴포넌트
+ * StepUpVerify를 모달로 감싸서 현재 페이지 위에 표시
+ */
+
+import { Dialog, DialogContent } from '@/components/ui/Modal'
+import { StepUpVerify } from '@/components/shared/StepUpVerify'
+
+interface OtpVerifyModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onVerified: () => void
+}
+
+export function OtpVerifyModal({ open, onOpenChange, onVerified }: OtpVerifyModalProps) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                showClose={false}
+                className="mx-4 max-w-sm py-10"
+                aria-describedby={undefined}
+            >
+                <StepUpVerify onVerified={onVerified} />
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+export default OtpVerifyModal

--- a/frontend/src/features/migration/components/customer/MigrationForm.tsx
+++ b/frontend/src/features/migration/components/customer/MigrationForm.tsx
@@ -97,7 +97,7 @@ export function MigrationForm() {
   if (!stepUpValid) {
     return (
       <div className="h-full bg-white flex flex-col pt-12">
-        <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 -mt-12 pt-12">
+        <div className="px-6 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 -mt-12 pt-12">
           <button
             onClick={() => customerNavigate('/migrations')}
             className="p-2 -ml-2 text-kkookk-steel hover:text-kkookk-navy"
@@ -117,7 +117,7 @@ export function MigrationForm() {
   return (
     <div className="h-full bg-white flex flex-col pt-12">
       {/* 헤더 */}
-      <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 -mt-12 pt-12">
+      <div className="px-6 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 -mt-12 pt-12">
         <button
           onClick={() => customerNavigate('/migrations')}
           className="p-2 -ml-2 text-kkookk-steel hover:text-kkookk-navy"

--- a/frontend/src/features/migration/components/customer/MigrationList.tsx
+++ b/frontend/src/features/migration/components/customer/MigrationList.tsx
@@ -6,12 +6,9 @@
 import { Badge } from "@/components/ui/Badge";
 import { formatShortDate } from "@/lib/utils/format";
 import type { MigrationListItemResponse, StampMigrationStatus } from "@/types/api";
-import { useState } from "react";
 import { ChevronLeft, Plus, FileText, Loader2 } from "lucide-react";
 import { useCustomerNavigate } from "@/hooks/useCustomerNavigate";
 import { useMigrationList } from "@/features/migration/hooks/useMigration";
-import { isStepUpValid } from "@/lib/api/tokenManager";
-import { StepUpVerify } from "@/components/shared/StepUpVerify";
 
 function getStatusBadge(status: StampMigrationStatus) {
   switch (status) {
@@ -28,15 +25,14 @@ function getStatusBadge(status: StampMigrationStatus) {
 
 export function MigrationList() {
   const { customerNavigate } = useCustomerNavigate();
-  const [stepUpValid, setStepUpValid] = useState(isStepUpValid());
   const { data: migrations, isLoading } = useMigrationList();
 
   const items: MigrationListItemResponse[] = migrations ?? [];
 
   return (
-    <div className="flex flex-col h-full pt-12">
+    <div className="flex flex-col h-full pt-6">
       {/* 헤더 */}
-      <div className="px-6 py-4 bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center justify-between sticky top-0 z-10 -mt-12 pt-12">
+      <div className="px-6 py-3 bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center justify-between sticky top-0 z-10 -mt-6 pt-6">
         <div className="flex items-center">
           <button
             onClick={() => customerNavigate("/wallet")}
@@ -49,24 +45,18 @@ export function MigrationList() {
             종이 스탬프 전환
           </h1>
         </div>
-        {stepUpValid && (
-          <button
-            onClick={() => customerNavigate("/migrations/new")}
-            className="flex items-center justify-center w-8 h-8 text-white transition-colors duration-100 bg-gray-500 rounded-lg hover:bg-kkookk-orange-500"
-            aria-label="새 신청"
-          >
-            <Plus size={20} />
-          </button>
-        )}
+        <button
+          onClick={() => customerNavigate("/migrations/new")}
+          className="flex items-center justify-center w-8 h-8 text-white transition-colors duration-100 bg-gray-500 rounded-lg hover:bg-kkookk-orange-500"
+          aria-label="새 신청"
+        >
+          <Plus size={20} />
+        </button>
       </div>
 
       {/* 목록 */}
       <div className="p-6 space-y-4 overflow-y-auto">
-        {!stepUpValid ? (
-          <div className="flex items-center justify-center mt-20">
-            <StepUpVerify onVerified={() => setStepUpValid(true)} />
-          </div>
-        ) : isLoading ? (
+        {isLoading ? (
           <div className="flex flex-col items-center justify-center mt-20 text-kkookk-steel">
             <Loader2 size={32} className="animate-spin opacity-40 mb-4" />
             <p>내역을 불러오는 중...</p>

--- a/frontend/src/features/redemption/components/RewardList.tsx
+++ b/frontend/src/features/redemption/components/RewardList.tsx
@@ -5,13 +5,10 @@
 
 import type { Reward } from "@/types/domain";
 import type { WalletRewardItem } from "@/types/api";
-import { useState } from "react";
 import { ChevronLeft, Gift, Loader2 } from "lucide-react";
 import { useCustomerNavigate } from "@/hooks/useCustomerNavigate";
 import { RewardCard } from "./RewardCard";
 import { useWalletRewards } from "@/features/wallet/hooks/useWallet";
-import { isStepUpValid } from "@/lib/api/tokenManager";
-import { StepUpVerify } from "@/components/shared/StepUpVerify";
 import { formatShortDate } from "@/lib/utils/format";
 
 function mapReward(item: WalletRewardItem): Reward {
@@ -29,7 +26,6 @@ function mapReward(item: WalletRewardItem): Reward {
 
 export function RewardList() {
   const { customerNavigate } = useCustomerNavigate();
-  const [stepUpValid, setStepUpValid] = useState(isStepUpValid());
   const { data, isLoading } = useWalletRewards();
 
   const rewards: Reward[] =
@@ -40,9 +36,9 @@ export function RewardList() {
   };
 
   return (
-    <div className="relative flex flex-col h-full pt-12">
+    <div className="relative flex flex-col h-full pt-6">
       {/* 헤더 */}
-      <div className="px-6 py-4 bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 z-10 -mt-12 pt-12">
+      <div className="px-6 py-3 bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 z-10 -mt-6 pt-6">
         <button
           onClick={() => customerNavigate("/wallet")}
           className="p-2 -ml-2 text-kkookk-steel hover:text-kkookk-navy"
@@ -57,11 +53,7 @@ export function RewardList() {
 
       {/* 리워드 목록 */}
       <div className="p-6 space-y-4 overflow-y-auto">
-        {!stepUpValid ? (
-          <div className="flex items-center justify-center py-20">
-            <StepUpVerify onVerified={() => setStepUpValid(true)} />
-          </div>
-        ) : isLoading ? (
+        {isLoading ? (
           <div className="flex flex-col items-center justify-center py-20 text-kkookk-steel">
             <Loader2 size={32} className="animate-spin opacity-40 mb-4" />
             <p>리워드를 불러오는 중...</p>

--- a/frontend/src/features/wallet/components/WalletHeader.tsx
+++ b/frontend/src/features/wallet/components/WalletHeader.tsx
@@ -3,7 +3,7 @@
  * 메뉴 토글이 있는 지갑 페이지 헤더
  */
 
-import { Menu } from 'lucide-react';
+import { Settings } from 'lucide-react';
 
 interface WalletHeaderProps {
   title?: string;
@@ -15,15 +15,15 @@ export function WalletHeader({
   onMenuClick,
 }: WalletHeaderProps) {
   return (
-    <div className="flex justify-between items-center px-6 pt-12 pb-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)]">
+    <div className="flex justify-between items-center px-6 pt-6 pb-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)]">
       <h1 className="text-2xl font-bold text-kkookk-navy">{title}</h1>
       <button
         onClick={onMenuClick}
         className="w-10 h-10 bg-white rounded-full shadow-sm flex items-center justify-center text-kkookk-navy hover:bg-slate-50 transition-colors"
-        title="메뉴 열기"
-        aria-label="메뉴 열기"
+        title="옵션 열기"
+        aria-label="옵션 열기"
       >
-        <Menu size={20} />
+        <Settings size={20} />
       </button>
     </div>
   );

--- a/frontend/src/features/wallet/pages/WalletPage.tsx
+++ b/frontend/src/features/wallet/pages/WalletPage.tsx
@@ -111,7 +111,7 @@ export function WalletPage() {
   // Loading state
   if (isLoading) {
     return (
-      <div className="flex-1 flex flex-col min-h-screen">
+      <div className="flex-1 flex flex-col h-full">
         <WalletHeader onMenuClick={() => setIsMenuOpen(true)} />
         <div className="flex-1 flex flex-col items-center justify-center">
           <Loader2 className="w-8 h-8 animate-spin text-kkookk-orange-500" />
@@ -124,7 +124,7 @@ export function WalletPage() {
   // Error state
   if (error) {
     return (
-      <div className="flex-1 flex flex-col min-h-screen">
+      <div className="flex-1 flex flex-col h-full">
         <WalletHeader onMenuClick={() => setIsMenuOpen(true)} />
         <div className="flex-1 flex flex-col items-center justify-center p-8">
           <AlertCircle className="w-12 h-12 text-red-500" />
@@ -144,7 +144,7 @@ export function WalletPage() {
   // Empty state
   if (cards.length === 0) {
     return (
-      <div className="flex-1 flex flex-col min-h-screen">
+      <div className="flex-1 flex flex-col h-full">
         <WalletHeader onMenuClick={() => setIsMenuOpen(true)} />
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
           <p className="text-lg font-medium text-kkookk-navy">아직 스탬프 카드가 없어요</p>
@@ -157,7 +157,7 @@ export function WalletPage() {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-screen">
+    <div className="flex-1 flex flex-col h-full">
       <WalletHeader onMenuClick={() => setIsMenuOpen(true)} />
 
       <div className="flex-1 flex flex-col justify-center pb-8">

--- a/frontend/src/pages/customer/CustomerHistoryPage.tsx
+++ b/frontend/src/pages/customer/CustomerHistoryPage.tsx
@@ -9,8 +9,6 @@ import { ChevronLeft, History, Check, Gift, Loader2 } from 'lucide-react';
 import { useCustomerNavigate } from '@/hooks/useCustomerNavigate';
 import { formatFullDateTime } from '@/lib/utils/format';
 import { useStampHistory, useRedeemHistory } from '@/features/wallet/hooks/useWallet';
-import { isStepUpValid } from '@/lib/api/tokenManager';
-import { StepUpVerify } from '@/components/shared/StepUpVerify';
 
 type HistoryFilter = 'all' | 'stamp' | 'reward';
 
@@ -26,8 +24,6 @@ export function CustomerHistoryPage() {
   const { storeId: defaultStoreId, customerNavigate } = useCustomerNavigate();
   const [searchParams] = useSearchParams();
   const [filter, setFilter] = useState<HistoryFilter>('all');
-  const [stepUpValid, setStepUpValid] = useState(isStepUpValid());
-
   // query param 우선, 없으면 sessionStorage/URL fallback
   const storeIdNum = Number(searchParams.get('storeId')) || (defaultStoreId ? Number(defaultStoreId) : undefined);
 
@@ -76,7 +72,7 @@ export function CustomerHistoryPage() {
   return (
     <div className="h-full bg-white flex flex-col">
       {/* 헤더 */}
-      <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 justify-between">
+      <div className="px-6 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 justify-between">
         <div className="flex items-center">
           <button
             onClick={() => customerNavigate('/wallet')}
@@ -112,11 +108,7 @@ export function CustomerHistoryPage() {
 
       {/* 목록 */}
       <div className="flex-1 overflow-y-auto px-6">
-        {!stepUpValid ? (
-          <div className="flex items-center justify-center py-16">
-            <StepUpVerify onVerified={() => setStepUpValid(true)} />
-          </div>
-        ) : isLoading ? (
+        {isLoading ? (
           <div className="flex flex-col items-center justify-center h-64 text-kkookk-steel">
             <Loader2 size={32} className="animate-spin opacity-40 mb-4" />
             <p>이력을 불러오는 중...</p>

--- a/frontend/src/pages/customer/CustomerSettingsPage.tsx
+++ b/frontend/src/pages/customer/CustomerSettingsPage.tsx
@@ -22,7 +22,7 @@ export function CustomerSettingsPage() {
   return (
     <div className="h-full flex flex-col">
       {/* 헤더 */}
-      <div className="px-6 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10">
+      <div className="px-6 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10">
         <button
           onClick={() => customerNavigate('/wallet')}
           className="p-2 -ml-2 text-kkookk-steel hover:text-kkookk-navy"


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #149 

## 📌 작업 내용 요약
고객 PWA에 하단 탭 네비게이션(BottomNavigationBar)을 추가하고, 분산되어 있던 본인 인증(StepUp) 로직을 CustomerLayout 레벨로 중앙화했습니다.

## 🚀 변경 사항
### 본인 인증 로직 중앙화 
- 기존: 각 페이지(`CustomerHistoryPage`, `RewardList`, `MigrationList`)마다 `isStepUpValid()` 체크 + `StepUpVerify` 렌더링이 분산되어 중복 코드 발생
- 변경: `CustomerLayout` 에서 BottomNav 탭 클릭을 인터셉트 → 미인증 시 OTP 모달 표시 → 인증 후 해당 탭으로 이동

### 사이드바 메뉴 개편
- 이전: 이력 / 리워드 보관함 / 종이 스탬프 전환 / 설정 
- 변경: 본인 인증 / 개인정보처리방침 / 버전 정보 

## 📎 참고 자료 (선택)
<img width="445" height="735" alt="스크린샷 2026-02-19 오전 9 14 46" src="https://github.com/user-attachments/assets/53681b77-4188-4232-9756-9003aef5dd75" />
<img width="1470" height="956" alt="스크린샷 2026-02-19 오전 9 14 49" src="https://github.com/user-attachments/assets/adfa94f6-63fb-4a86-8a87-4d832aa1b3e0" />
<img width="1470" height="956" alt="스크린샷 2026-02-19 오전 9 14 53" src="https://github.com/user-attachments/assets/f079ee17-8714-4350-9d7b-5127bac39cc2" />
