### PR TITLE
RefreshToken 연동 버그 수정 및 안내 문구 UI 개선

### DIFF
--- a/backend/src/main/java/com/project/kkookk/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/kkookk/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -63,6 +65,10 @@ public class SecurityConfig {
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())
+                .exceptionHandling(
+                        ex ->
+                                ex.authenticationEntryPoint(
+                                        new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .addFilterBefore(
                         jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/project/kkookk/owner/service/OwnerAuthService.java
+++ b/backend/src/main/java/com/project/kkookk/owner/service/OwnerAuthService.java
@@ -62,6 +62,9 @@ public class OwnerAuthService {
         String accessToken =
                 jwtUtil.generateOwnerToken(
                         ownerAccount.getId(), ownerAccount.getEmail(), ownerAccount.isAdmin());
+        String refreshToken =
+                refreshTokenService.issueOwnerRefreshToken(
+                        ownerAccount.getId(), ownerAccount.getEmail(), ownerAccount.isAdmin());
         log.info("[Auth] Owner login success ownerId={}", ownerAccount.getId());
 
         return OwnerLoginResponse.of(accessToken, refreshToken, ownerAccount);

--- a/backend/src/main/java/com/project/kkookk/wallet/service/CustomerWalletService.java
+++ b/backend/src/main/java/com/project/kkookk/wallet/service/CustomerWalletService.java
@@ -81,18 +81,6 @@ public class CustomerWalletService {
         return !customerWalletRepository.existsByPhone(normalizePhone(phone));
     }
 
-    private String normalizePhone(String phone) {
-        return phone.replaceAll("[^0-9]", "");
-    }
-
-    public boolean checkNicknameAvailable(String nickname) {
-        return !customerWalletRepository.existsByNickname(nickname);
-    }
-
-    public boolean checkPhoneAvailable(String phone) {
-        return !customerWalletRepository.existsByPhone(normalizePhone(phone));
-    }
-
     @Transactional
     public WalletRegisterResponse register(WalletRegisterRequest request) {
         String phone = normalizePhone(request.phone());

--- a/frontend/src/features/issuance/components/customer/RequestStampButton.tsx
+++ b/frontend/src/features/issuance/components/customer/RequestStampButton.tsx
@@ -269,12 +269,6 @@ export function RequestStampButton() {
         )}
       </div>
 
-      <div className="mb-6 px-4">
-        <p className="text-xs text-kkookk-steel text-center leading-relaxed">
-          리워드 사용 시 사장님 확인이 필요합니다.
-        </p>
-      </div>
-
       <div className="space-y-3 w-full">
         <Button
           onClick={handleRequest}

--- a/frontend/src/features/migration/components/customer/MigrationForm.tsx
+++ b/frontend/src/features/migration/components/customer/MigrationForm.tsx
@@ -4,16 +4,28 @@
  * API 연동: createMigration({ storeId, imageData, claimedStampCount })
  */
 
-import { useMemo, useRef, useState } from 'react';
-import { ChevronLeft, ChevronDown, Camera, Check, Info, AlertCircle, Loader2, Store } from 'lucide-react';
-import { useCustomerNavigate } from '@/hooks/useCustomerNavigate';
-import { Button } from '@/components/ui/Button';
-import { Input } from '@/components/ui/Input';
-import { StepUpVerify } from '@/components/shared/StepUpVerify';
-import { isStepUpValid } from '@/lib/api/tokenManager';
-import { useCreateMigration, useMigrationList } from '@/features/migration/hooks/useMigration';
-import { kkookkToast } from '@/components/ui/Toast';
-import { useAllWalletStampCards } from '@/features/wallet/hooks/useWallet';
+import { StepUpVerify } from "@/components/shared/StepUpVerify";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { kkookkToast } from "@/components/ui/Toast";
+import {
+  useCreateMigration,
+  useMigrationList,
+} from "@/features/migration/hooks/useMigration";
+import { useAllWalletStampCards } from "@/features/wallet/hooks/useWallet";
+import { useCustomerNavigate } from "@/hooks/useCustomerNavigate";
+import { isStepUpValid } from "@/lib/api/tokenManager";
+import {
+  AlertCircle,
+  Camera,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  Info,
+  Loader2,
+  Store,
+} from "lucide-react";
+import { useMemo, useRef, useState } from "react";
 
 /** File → Base64 data URI */
 function fileToBase64(file: File): Promise<string> {
@@ -30,9 +42,11 @@ export function MigrationForm() {
   const originStoreId = urlStoreId ? Number(urlStoreId) : undefined;
 
   const [stepUpValid, setStepUpValid] = useState(isStepUpValid());
-  const [selectedStoreId, setSelectedStoreId] = useState<number | undefined>(originStoreId);
+  const [selectedStoreId, setSelectedStoreId] = useState<number | undefined>(
+    originStoreId,
+  );
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [count, setCount] = useState('');
+  const [count, setCount] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -58,10 +72,10 @@ export function MigrationForm() {
     () =>
       new Set(
         (migrations ?? [])
-          .filter((m) => m.status === 'SUBMITTED')
-          .map((m) => m.storeId)
+          .filter((m) => m.status === "SUBMITTED")
+          .map((m) => m.storeId),
       ),
-    [migrations]
+    [migrations],
   );
 
   // 선택 가능한 매장 먼저, 심사 중 매장 뒤로
@@ -70,14 +84,16 @@ export function MigrationForm() {
       ...availableStores.filter((s) => !pendingStoreIds.has(s.storeId)),
       ...availableStores.filter((s) => pendingStoreIds.has(s.storeId)),
     ],
-    [availableStores, pendingStoreIds]
+    [availableStores, pendingStoreIds],
   );
 
-  const selectedStoreName = availableStores.find((s) => s.storeId === selectedStoreId)?.storeName;
+  const selectedStoreName = availableStores.find(
+    (s) => s.storeId === selectedStoreId,
+  )?.storeName;
 
   const isFormValid =
     selectedStoreId !== undefined &&
-    count.trim() !== '' &&
+    count.trim() !== "" &&
     Number(count) >= 1 &&
     file !== null &&
     !pendingStoreIds.has(selectedStoreId);
@@ -104,26 +120,26 @@ export function MigrationForm() {
         },
         {
           onSuccess: () => {
-            kkookkToast.success('전환 신청이 접수되었습니다');
-            customerNavigate('/migrations');
+            kkookkToast.success("전환 신청이 접수되었습니다");
+            customerNavigate("/migrations");
           },
           onError: (error) => {
             const err = error as { response?: { status?: number } };
             if (err.response?.status === 409) {
-              setSubmitError('이미 심사 중인 전환 신청이 있습니다.');
+              setSubmitError("이미 심사 중인 전환 신청이 있습니다.");
             } else if (err.response?.status === 413) {
-              setSubmitError('이미지 크기가 너무 큽니다. (최대 5MB)');
+              setSubmitError("이미지 크기가 너무 큽니다. (최대 5MB)");
             } else if (err.response?.status === 403) {
-              setSubmitError('본인 인증이 만료되었습니다. 다시 인증해주세요.');
+              setSubmitError("본인 인증이 만료되었습니다. 다시 인증해주세요.");
               setStepUpValid(false);
             } else {
-              setSubmitError('전환 신청에 실패했습니다. 다시 시도해주세요.');
+              setSubmitError("전환 신청에 실패했습니다. 다시 시도해주세요.");
             }
           },
-        }
+        },
       );
     } catch {
-      setSubmitError('이미지 처리 중 오류가 발생했습니다.');
+      setSubmitError("이미지 처리 중 오류가 발생했습니다.");
     }
   };
 
@@ -133,13 +149,15 @@ export function MigrationForm() {
       <div className="h-full bg-white flex flex-col pt-12">
         <div className="px-6 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 -mt-12 pt-12">
           <button
-            onClick={() => customerNavigate('/migrations')}
+            onClick={() => customerNavigate("/migrations")}
             className="p-2 -ml-2 text-kkookk-steel hover:text-kkookk-navy"
             aria-label="뒤로 가기"
           >
             <ChevronLeft size={24} />
           </button>
-          <h1 className="font-bold text-lg ml-2 text-kkookk-navy">전환 신청하기</h1>
+          <h1 className="font-bold text-lg ml-2 text-kkookk-navy">
+            전환 신청하기
+          </h1>
         </div>
         <div className="flex-1 flex items-center justify-center">
           <StepUpVerify onVerified={() => setStepUpValid(true)} />
@@ -153,13 +171,15 @@ export function MigrationForm() {
       {/* 헤더 */}
       <div className="px-6 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)] flex items-center sticky top-0 bg-white z-10 -mt-12 pt-12">
         <button
-          onClick={() => customerNavigate('/migrations')}
+          onClick={() => customerNavigate("/migrations")}
           className="p-2 -ml-2 text-kkookk-steel hover:text-kkookk-navy"
           aria-label="뒤로 가기"
         >
           <ChevronLeft size={24} />
         </button>
-        <h1 className="font-bold text-lg ml-2 text-kkookk-navy">전환 신청하기</h1>
+        <h1 className="font-bold text-lg ml-2 text-kkookk-navy">
+          전환 신청하기
+        </h1>
       </div>
 
       {/* 폼 콘텐츠 */}
@@ -169,7 +189,6 @@ export function MigrationForm() {
           <Info size={20} className="shrink-0" />
           <div>
             <p className="font-bold mb-1">안내사항</p>
-            <p>• 매장별로 1회만 전환 신청이 가능합니다.</p>
             <p>• 신청 후 승인까지 약 24~48시간 소요됩니다.</p>
           </div>
         </div>
@@ -186,24 +205,32 @@ export function MigrationForm() {
                 type="button"
                 onClick={() => setIsDropdownOpen((prev) => !prev)}
                 className={[
-                  'w-full flex items-center justify-between px-4 py-3.5 rounded-xl border text-sm transition-colors',
+                  "w-full flex items-center justify-between px-4 py-3.5 rounded-xl border text-sm transition-colors",
                   isDropdownOpen
-                    ? 'border-kkookk-orange-500 bg-white'
-                    : 'border-slate-200 bg-white hover:border-slate-300',
-                ].join(' ')}
+                    ? "border-kkookk-orange-500 bg-white"
+                    : "border-slate-200 bg-white hover:border-slate-300",
+                ].join(" ")}
               >
                 <div className="flex items-center gap-2.5">
                   <Store
                     size={16}
-                    className={selectedStoreName ? 'text-kkookk-navy' : 'text-slate-400'}
+                    className={
+                      selectedStoreName ? "text-kkookk-navy" : "text-slate-400"
+                    }
                   />
-                  <span className={selectedStoreName ? 'text-kkookk-navy font-medium' : 'text-slate-400'}>
-                    {selectedStoreName ?? '매장을 선택하세요'}
+                  <span
+                    className={
+                      selectedStoreName
+                        ? "text-kkookk-navy font-medium"
+                        : "text-slate-400"
+                    }
+                  >
+                    {selectedStoreName ?? "매장을 선택하세요"}
                   </span>
                 </div>
                 <ChevronDown
                   size={16}
-                  className={`text-slate-400 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+                  className={`text-slate-400 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
                 />
               </button>
 
@@ -233,19 +260,19 @@ export function MigrationForm() {
                             disabled={isPending}
                             onClick={() => handleStoreSelect(store.storeId)}
                             className={[
-                              'w-full flex items-center justify-between px-4 py-3 text-sm text-left border-b border-slate-100 last:border-b-0 transition-colors',
+                              "w-full flex items-center justify-between px-4 py-3 text-sm text-left border-b border-slate-100 last:border-b-0 transition-colors",
                               isPending
-                                ? 'opacity-50 cursor-not-allowed bg-white'
+                                ? "opacity-50 cursor-not-allowed bg-white"
                                 : isSelected
-                                ? 'bg-kkookk-orange-50'
-                                : 'hover:bg-slate-50',
-                            ].join(' ')}
+                                  ? "bg-kkookk-orange-50"
+                                  : "hover:bg-slate-50",
+                            ].join(" ")}
                           >
                             <span
                               className={
                                 isSelected && !isPending
-                                  ? 'font-medium text-kkookk-navy'
-                                  : 'text-kkookk-steel'
+                                  ? "font-medium text-kkookk-navy"
+                                  : "text-kkookk-steel"
                               }
                             >
                               {store.storeName}
@@ -257,7 +284,10 @@ export function MigrationForm() {
                                 </span>
                               )}
                               {isSelected && !isPending && (
-                                <Check size={14} className="text-kkookk-orange-500" />
+                                <Check
+                                  size={14}
+                                  className="text-kkookk-orange-500"
+                                />
                               )}
                             </div>
                           </button>
@@ -272,7 +302,10 @@ export function MigrationForm() {
 
           {/* 스탬프 개수 */}
           <div>
-            <label htmlFor="count-input" className="block text-xs font-bold text-kkookk-navy mb-2">
+            <label
+              htmlFor="count-input"
+              className="block text-xs font-bold text-kkookk-navy mb-2"
+            >
               보유 스탬프 개수 <span className="text-kkookk-orange-500">*</span>
             </label>
             <Input
@@ -291,7 +324,8 @@ export function MigrationForm() {
               htmlFor="photo-upload"
               className="block text-sm font-bold text-kkookk-navy mb-2"
             >
-              종이 쿠폰 사진 첨부 <span className="text-kkookk-orange-500">*</span>
+              종이 쿠폰 사진 첨부{" "}
+              <span className="text-kkookk-orange-500">*</span>
             </label>
             <p className="text-xs text-kkookk-steel mb-2">
               <span className="text-rose-600">• 파일 크기: 3MB 이하</span>
@@ -308,8 +342,10 @@ export function MigrationForm() {
 
                   const maxSize = 3 * 1024 * 1024;
                   if (selectedFile.size > maxSize) {
-                    alert('파일 크기가 너무 큽니다.\n3MB 이하의 이미지를 선택해주세요.');
-                    e.target.value = '';
+                    alert(
+                      "파일 크기가 너무 큽니다.\n3MB 이하의 이미지를 선택해주세요.",
+                    );
+                    e.target.value = "";
                     return;
                   }
 
@@ -320,7 +356,9 @@ export function MigrationForm() {
                 {file ? (
                   <>
                     <Check size={32} className="text-green-500 mb-2" />
-                    <p className="text-sm font-bold text-kkookk-navy">{file.name}</p>
+                    <p className="text-sm font-bold text-kkookk-navy">
+                      {file.name}
+                    </p>
                   </>
                 ) : (
                   <>
@@ -357,7 +395,7 @@ export function MigrationForm() {
               제출 중...
             </>
           ) : (
-            '제출하기'
+            "제출하기"
           )}
         </Button>
       </div>

--- a/frontend/src/features/redemption/components/RedeemScreen.tsx
+++ b/frontend/src/features/redemption/components/RedeemScreen.tsx
@@ -3,23 +3,23 @@
  * "사장님 확인중" 화면 → 직원 확인 모달 → 단일 API 호출로 리딤 처리
  */
 
-import { useState, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
-import { Loader2 } from 'lucide-react';
-import { useCustomerNavigate } from '@/hooks/useCustomerNavigate';
-import { StaffConfirmModal } from './StaffConfirmModal';
-import { RedeemResultView } from './RedeemResultView';
-import { Button } from '@/components/ui/Button';
-import { kkookkToast } from '@/components/ui/Toast';
-import { useRedeemReward } from '../hooks/useRedeem';
+import { Button } from "@/components/ui/Button";
+import { kkookkToast } from "@/components/ui/Toast";
+import { useCustomerNavigate } from "@/hooks/useCustomerNavigate";
+import { ChevronLeft, Loader2 } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useRedeemReward } from "../hooks/useRedeem";
+import { RedeemResultView } from "./RedeemResultView";
+import { StaffConfirmModal } from "./StaffConfirmModal";
 
-type RedeemState = 'confirming' | 'completing' | 'success' | 'failed';
+type RedeemState = "confirming" | "completing" | "success" | "failed";
 
 export function RedeemScreen() {
   const { customerNavigate } = useCustomerNavigate();
   const { redeemId } = useParams<{ redeemId: string }>();
 
-  const [redeemState, setRedeemState] = useState<RedeemState>('confirming');
+  const [redeemState, setRedeemState] = useState<RedeemState>("confirming");
   const [showStaffConfirm, setShowStaffConfirm] = useState(false);
   const redeemReward = useRedeemReward();
 
@@ -27,18 +27,18 @@ export function RedeemScreen() {
     setShowStaffConfirm(false);
     if (!redeemId) return;
 
-    setRedeemState('completing');
+    setRedeemState("completing");
     redeemReward.mutate(
       { walletRewardId: Number(redeemId) },
       {
         onSuccess: () => {
-          setRedeemState('success');
+          setRedeemState("success");
         },
         onError: () => {
-          setRedeemState('failed');
-          kkookkToast.error('리워드 사용 처리에 실패했습니다');
+          setRedeemState("failed");
+          kkookkToast.error("리워드 사용 처리에 실패했습니다");
         },
-      }
+      },
     );
   }, [redeemId, redeemReward]);
 
@@ -47,11 +47,11 @@ export function RedeemScreen() {
   }, []);
 
   const handleBackToList = useCallback(() => {
-    customerNavigate('/redeems');
+    customerNavigate("/redeems");
   }, [customerNavigate]);
 
   // Completing state
-  if (redeemState === 'completing') {
+  if (redeemState === "completing") {
     return (
       <div className="h-full flex flex-col items-center justify-center bg-red-50">
         <Loader2 className="w-8 h-8 animate-spin text-kkookk-orange-500" />
@@ -61,40 +61,56 @@ export function RedeemScreen() {
   }
 
   // Success state
-  if (redeemState === 'success') {
+  if (redeemState === "success") {
     return <RedeemResultView success={true} onConfirm={handleBackToList} />;
   }
 
   // Failed state
-  if (redeemState === 'failed') {
+  if (redeemState === "failed") {
     return <RedeemResultView success={false} onConfirm={handleBackToList} />;
   }
 
   // Confirming state — "사장님 확인중" 화면
   return (
-    <div className="h-full flex flex-col p-6 justify-center text-center bg-red-50 relative">
-      <div className="flex-1 flex flex-col justify-center w-full">
-        <div className="bg-white p-8 rounded-2xl shadow-xl w-full">
-          <h2 className="text-xl font-bold text-kkookk-red mb-2">
-            사장님 확인 중
-          </h2>
-          <p className="text-kkookk-steel text-sm mb-6">
-            화면을 직원에게 보여주세요
-          </p>
-
-          {/* 직원 액션 버튼 */}
-          <div className="mt-8 pt-6 border-t border-slate-100">
-            <Button
-              onClick={() => setShowStaffConfirm(true)}
-              variant="navy"
-              size="full"
-              className="animate-pulse text-lg"
+    <div className="h-full flex flex-col bg-red-50 relative">
+      <div className="flex-1 flex flex-col justify-center w-full p-6 text-center">
+        <div className="bg-white rounded-2xl shadow-xl w-full overflow-hidden">
+          {/* 카드 내 헤더 */}
+          <div className="px-4 py-3 flex items-center ">
+            <button
+              onClick={handleBackToList}
+              className="p-1 -ml-1 text-kkookk-steel hover:text-kkookk-navy"
+              aria-label="뒤로 가기"
             >
-              사용 처리 완료 (직원용)
-            </Button>
-            <p className="text-[10px] text-kkookk-steel mt-3">
-              직원이 직접 버튼을 눌러주세요
+              <ChevronLeft size={20} />
+            </button>
+            <span className="ml-1 text-sm font-medium text-kkookk-steel">
+              리워드 사용
+            </span>
+          </div>
+
+          <div className="p-8">
+            <h2 className="text-xl font-bold text-kkookk-red mb-2">
+              사장님 확인 중
+            </h2>
+            <p className="text-kkookk-steel text-sm mb-6">
+              화면을 직원에게 보여주세요
             </p>
+
+            {/* 직원 액션 버튼 */}
+            <div className="pt-4">
+              <Button
+                onClick={() => setShowStaffConfirm(true)}
+                variant="navy"
+                size="full"
+                className="animate-pulse text-lg"
+              >
+                사용 처리 완료 (직원용)
+              </Button>
+              <p className="text-[10px] text-kkookk-steel mt-3">
+                직원이 직접 버튼을 눌러주세요
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/features/redemption/components/RewardList.tsx
+++ b/frontend/src/features/redemption/components/RewardList.tsx
@@ -5,7 +5,7 @@
 
 import type { Reward } from "@/types/domain";
 import type { WalletRewardItem } from "@/types/api";
-import { ChevronLeft, Gift, Loader2 } from "lucide-react";
+import { ChevronLeft, Gift, Info, Loader2 } from "lucide-react";
 import { useCustomerNavigate } from "@/hooks/useCustomerNavigate";
 import { RewardCard } from "./RewardCard";
 import { useWalletRewards } from "@/features/wallet/hooks/useWallet";
@@ -53,6 +53,12 @@ export function RewardList() {
 
       {/* 리워드 목록 */}
       <div className="p-6 space-y-4 overflow-y-auto">
+        {/* 안내 문구 */}
+        <div className="flex items-center gap-1.5 text-kkookk-steel">
+          <Info size={12} className="shrink-0 opacity-60" />
+          <p className="text-[11px] leading-relaxed">리워드 사용 시 사장님 확인이 필요합니다.</p>
+        </div>
+
         {isLoading ? (
           <div className="flex flex-col items-center justify-center py-20 text-kkookk-steel">
             <Loader2 size={32} className="animate-spin opacity-40 mb-4" />


### PR DESCRIPTION
## 🔗 관련 이슈
- 이슈없음

## 📌 작업 내용 요약
RefreshToken 자동 갱신 시스템 도입 후 발생한 컴파일 에러 수정 및 안내 문구 위치 UI 개선

## 🚀 변경 사항

### 백엔드 버그 수정

- **`OwnerAuthService`**: `login()` 메서드에서 `refreshToken` 변수가 선언되지 않은 채 참조되어 컴파일 에러 발생 → `refreshTokenService.issueOwnerRefreshToken()` 호출 추가
- **`CustomerWalletService`**: `normalizePhone` / `checkNicknameAvailable` / `checkPhoneAvailable` 메서드 중복 선언으로 컴파일 에러 발생 → 중복 제거
- **`SecurityConfig`**: `exceptionHandling` 누락으로 미인증 요청에 403이 반환되던 문제 → `authenticationEntryPoint(401)` 추가

> **근본 원인**: 두 컴파일 에러로 인해 빌드가 되지 않아 refresh token을 반환하지 않는 구버전 바이너리가 실행 중이었음. 이에 따라 프론트엔드 localStorage에 `refresh_token: "undefined"`가 저장되어, 15분 후 access token 만료 시 갱신 실패 → 403 에러 발생

### 프론트엔드 UI 개선

- **`RewardList`**: "리워드 사용 시 사장님 확인이 필요합니다" 안내 문구를 리워드 목록 상단으로 이동 (적립 버튼 화면에서는 불필요)
- **`RequestStampButton`**: 위 안내 문구 제거 (중복)
- **`RedeemScreen`**: 사장님 확인 화면에 카드 헤더 및 뒤로 가기 버튼 추가
- **`MigrationForm`**: "매장별로 1회만 전환 신청이 가능합니다" 안내 문구 제거
