### PR TITLE
feat: 고객 지갑 UI/UX 개선 - 스탬프 그리드 내 적립 버튼 + 도장 애니메이션

### DIFF
--- a/frontend/src/features/issuance/components/customer/RequestStampButton.tsx
+++ b/frontend/src/features/issuance/components/customer/RequestStampButton.tsx
@@ -12,8 +12,6 @@ import { kkookkToast } from '@/components/ui/Toast';
 import { useCustomerNavigate } from '@/hooks/useCustomerNavigate';
 import { useWalletStampCards } from '@/features/wallet/hooks/useWallet';
 import { useCreateIssuanceRequest, useIssuanceRequestStatus, useCancelIssuanceRequest, generateIdempotencyKey } from '@/features/issuance/hooks/useIssuance';
-import { getWalletStampCards } from '@/features/wallet/api/walletApi';
-import { QUERY_KEYS } from '@/lib/api/endpoints';
 import { RequestingView } from './RequestingView';
 import { RequestResultView } from './RequestResultView';
 import { RewardAchievedView } from './RewardAchievedView';
@@ -118,6 +116,17 @@ export function RequestStampButton() {
     customerNavigate('/wallet');
   };
 
+  const handleBackWithAnimation = () => {
+    customerNavigate('/wallet', {
+      state: {
+        stampJustAdded: true,
+        animateStampIndex: (requestStatus?.currentStampCount ?? 1) - 1,
+        stampedCardId: cardId,
+      },
+      replace: true,
+    });
+  };
+
   const handleGoToRewards = () => {
     customerNavigate('/redeems');
   };
@@ -127,14 +136,7 @@ export function RequestStampButton() {
     setIsNavigating(true);
     try {
       await queryClient.invalidateQueries({ queryKey: ['wallet'] });
-      const fresh = await queryClient.fetchQuery({
-        queryKey: QUERY_KEYS.walletStampCards(storeIdNum),
-        queryFn: () => getWalletStampCards(storeIdNum),
-      });
-      const newCard = fresh?.stampCards
-        ?.filter((c) => c.store.storeId === storeIdNum && c.currentStampCount === 0)
-        ?.sort((a, b) => b.walletStampCardId - a.walletStampCardId)?.[0];
-      customerNavigate(newCard ? `/wallet/${newCard.walletStampCardId}` : '/wallet');
+      customerNavigate('/wallet');
     } catch {
       customerNavigate('/wallet');
     } finally {
@@ -234,7 +236,7 @@ export function RequestStampButton() {
       <RequestResultView
         success={true}
         stampCount={requestStatus?.currentStampCount}
-        onConfirm={handleBack}
+        onConfirm={handleBackWithAnimation}
       />
     );
   }

--- a/frontend/src/features/wallet/components/CardInfoPanel.tsx
+++ b/frontend/src/features/wallet/components/CardInfoPanel.tsx
@@ -1,25 +1,19 @@
 /**
  * CardInfoPanel 컴포넌트
  * 캐러셀 카드 아래: 가게 이름만 표시
- * 모바일에서만 "스탬프 찍기" 버튼 표시 (showButton)
  */
 
 import { motion, AnimatePresence } from 'framer-motion'
-import { Smartphone } from 'lucide-react'
-import { Button } from '@/components/ui/Button'
 import { cn } from '@/lib/utils'
 import type { StampCard } from '@/types/domain'
 
 interface CardInfoPanelProps {
     card: StampCard
-    onStampClick: () => void
-    showButton?: boolean
     direction?: 1 | -1
     className?: string
 }
 
-export function CardInfoPanel({ card, onStampClick, showButton = true, direction = 1, className }: CardInfoPanelProps) {
-    const isComplete = card.current >= card.max
+export function CardInfoPanel({ card, direction = 1, className }: CardInfoPanelProps) {
     const slideX = 40 * direction
 
     return (
@@ -40,35 +34,6 @@ export function CardInfoPanel({ card, onStampClick, showButton = true, direction
                     >
                         {card.storeName}
                     </h2>
-
-                    {/* 액션 버튼 (모바일에서만) */}
-                    {showButton && (
-                        <div className="mt-4 w-full">
-                            {isComplete ? (
-                                <Button
-                                    onClick={onStampClick}
-                                    variant="navy"
-                                    size="full"
-                                    className="h-12 rounded-xl text-sm font-bold"
-                                >
-                                    <Smartphone size={16} className="mr-1.5" />
-                                    리워드 사용하기
-                                </Button>
-                            ) : (
-                                <Button
-                                    onClick={onStampClick}
-                                    variant="primary"
-                                    size="full"
-                                    className="h-12 rounded-xl text-sm font-bold"
-                                    style={{
-                                        boxShadow: '0 4px 14px -3px rgba(255, 77, 0, 0.4), 0 2px 6px -2px rgba(255, 77, 0, 0.2)',
-                                    }}
-                                >
-                                    스탬프 찍기
-                                </Button>
-                            )}
-                        </div>
-                    )}
                 </motion.div>
             </AnimatePresence>
         </div>

--- a/frontend/src/features/wallet/components/StampCardBack.tsx
+++ b/frontend/src/features/wallet/components/StampCardBack.tsx
@@ -2,15 +2,25 @@
  * StampCardBack 컴포넌트
  * 카드 뒷면 - 스탬프 진행도 + 보상 정보 + 도장 그리드
  * 가로형 (1.58:1), backfaceVisibility/rotateY는 부모에서 처리
+ *
+ * 그리드 슬롯 유형:
+ * - 채워진 스탬프: 체크 또는 stampImage
+ * - 적립 버튼: 다음 빈 슬롯에 Plus 아이콘 (펄스 애니메이션)
+ * - 애니메이션 스탬프: 실물 도장 내려찍기 (위→아래 + 충격 파동)
+ * - 빈 슬롯: 슬롯 번호
  */
 
-import { Check } from 'lucide-react'
+import { Check, Plus } from 'lucide-react'
+import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import type { StampCard } from '@/types/domain'
 
 interface StampCardBackProps {
     card: StampCard
     className?: string
+    onStampRequest?: () => void
+    animatingStampIndex?: number
+    onAnimationComplete?: () => void
 }
 
 function getGridCols(max: number): string {
@@ -20,7 +30,7 @@ function getGridCols(max: number): string {
     return 'grid-cols-5'
 }
 
-export function StampCardBack({ card, className }: StampCardBackProps) {
+export function StampCardBack({ card, className, onStampRequest, animatingStampIndex, onAnimationComplete }: StampCardBackProps) {
     const stampColor = card.stampColor || 'bg-kkookk-orange-500'
     const gridCols = getGridCols(card.max)
     const isComplete = card.current >= card.max
@@ -69,6 +79,84 @@ export function StampCardBack({ card, className }: StampCardBackProps) {
             )}>
                 {Array.from({ length: card.max }).map((_, i) => {
                     const isActive = i < card.current
+                    const isAnimating = animatingStampIndex === i && isActive
+                    const isStampButton = i === card.current && !isComplete && animatingStampIndex === undefined
+
+                    // 도장 찍기 애니메이션 슬롯 (실물 도장 느낌)
+                    if (isAnimating) {
+                        return (
+                            <motion.div
+                                key={i}
+                                className={cn(
+                                    'aspect-square w-full rounded-full flex items-center justify-center',
+                                    stampColor, 'text-white',
+                                )}
+                                style={{
+                                    boxShadow: '0 2px 8px -2px rgba(0,0,0,0.15), 0 1px 3px -1px rgba(0,0,0,0.1)',
+                                }}
+                                initial={{ y: -30, scale: 1.4, opacity: 0, rotate: -12 }}
+                                animate={{
+                                    y: [null, 2, 0],
+                                    scale: [null, 0.88, 1],
+                                    opacity: [null, 1, 1],
+                                    rotate: [null, 2, 0],
+                                }}
+                                transition={{
+                                    duration: 0.8,
+                                    times: [0, 0.55, 1],
+                                    ease: [0.22, 1, 0.36, 1],
+                                    delay: 0.25,
+                                }}
+                                onAnimationComplete={onAnimationComplete}
+                            >
+                                {card.stampImage ? (
+                                    <img
+                                        src={card.stampImage}
+                                        alt="stamp"
+                                        className="w-full h-full object-cover rounded-full"
+                                    />
+                                ) : (
+                                    <Check size={14} strokeWidth={3} />
+                                )}
+                            </motion.div>
+                        )
+                    }
+
+                    // 적립 버튼 슬롯 (애니메이션 중에는 숨김)
+                    if (isStampButton) {
+                        return (
+                            <motion.button
+                                key={i}
+                                type="button"
+                                className={cn(
+                                    'aspect-square w-full rounded-full flex items-center justify-center',
+                                    'border-2 border-dashed border-kkookk-orange-400',
+                                    'bg-kkookk-orange-50 text-kkookk-orange-500',
+                                    'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-kkookk-orange-500',
+                                )}
+                                initial={{ scale: 0, opacity: 0 }}
+                                animate={{ scale: [1, 1.15, 1], opacity: 1 }}
+                                transition={{
+                                    scale: { duration: 2, repeat: Infinity, ease: 'easeInOut' },
+                                    opacity: { duration: 0.25 },
+                                }}
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    onStampRequest?.()
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.stopPropagation()
+                                    }
+                                }}
+                                aria-label="스탬프 적립 요청"
+                            >
+                                <Plus size={14} strokeWidth={3} />
+                            </motion.button>
+                        )
+                    }
+
+                    // 채워진 스탬프 또는 빈 슬롯
                     return (
                         <div
                             key={i}

--- a/frontend/src/features/wallet/components/StampCardCarousel.tsx
+++ b/frontend/src/features/wallet/components/StampCardCarousel.tsx
@@ -1,10 +1,10 @@
 /**
  * StampCardCarousel 컴포넌트
  * 가로형 스탬프 카드 캐러셀 (심플 스케일 전환)
- * - 중앙 카드: 크게 표시, hover/tap으로 3D 플립
+ * - 중앙 카드: 크게 표시, tap/click으로 3D 플립
  * - 좌우 카드: 중앙 기준 좌우에 작게 + 반투명 (PC/모바일 모두)
- * - 모바일: tap → 플립, 스와이프로 전환, 하단 "스탬프 찍기" 버튼
- * - PC: hover → 플립, click → 적립요청, 가로 스크롤(휠)로 전환
+ * - 스와이프(모바일) / 휠 스크롤(PC)로 전환
+ * - 그리드 내 적립 버튼으로 적립 요청
  */
 
 import { useCallback, useState, useEffect, useRef } from 'react'
@@ -17,8 +17,12 @@ import { CardInfoPanel } from './CardInfoPanel'
 
 interface StampCardCarouselProps {
     cards: StampCard[]
-    onCardSelect: (card: StampCard) => void
+    initialIndex?: number
     onCardChange?: (card: StampCard) => void
+    onStampRequest?: (card: StampCard) => void
+    initialFlipped?: boolean
+    animatingStampIndex?: number
+    onAnimationComplete?: () => void
     className?: string
 }
 
@@ -45,12 +49,16 @@ function useIsTouchDevice() {
 
 export function StampCardCarousel({
     cards,
-    onCardSelect,
+    initialIndex = 0,
     onCardChange,
+    onStampRequest,
+    initialFlipped,
+    animatingStampIndex,
+    onAnimationComplete,
     className,
 }: StampCardCarouselProps) {
-    const [currentIndex, setCurrentIndex] = useState(0)
-    const [isFlipped, setIsFlipped] = useState(false)
+    const [currentIndex, setCurrentIndex] = useState(initialIndex)
+    const [isFlipped, setIsFlipped] = useState(initialFlipped ?? false)
     const [slideDirection, setSlideDirection] = useState<1 | -1>(1)
     const isTouchDevice = useIsTouchDevice()
     const wheelAccum = useRef(0)
@@ -83,29 +91,12 @@ export function StampCardCarousel({
         [currentIndex, cards.length, goTo],
     )
 
+    // 클릭/탭: 항상 플립 토글
     const handleCenterClick = useCallback(() => {
-        if (isTouchDevice) {
-            setIsFlipped((prev) => !prev)
-        } else {
-            onCardSelect(cards[currentIndex])
-        }
-    }, [isTouchDevice, onCardSelect, cards, currentIndex])
-
-    const handleHoverStart = useCallback(() => {
-        if (!isTouchDevice) {
-            setIsFlipped(true)
-        }
-    }, [isTouchDevice])
-
-    const handleHoverEnd = useCallback(() => {
-        if (!isTouchDevice) {
-            setIsFlipped(false)
-        }
-    }, [isTouchDevice])
+        setIsFlipped((prev) => !prev)
+    }, [])
 
     // PC: 가로 스크롤(휠/트랙패드)로 캐러셀 전환
-    // 항상 preventDefault로 Mac 브라우저 뒤로/앞으로 방지
-    // delta 누적 방식으로 트랙패드 민감도 개선
     useEffect(() => {
         const el = carouselRef.current
         if (!el || isTouchDevice) return
@@ -113,13 +104,11 @@ export function StampCardCarousel({
         const ACCUM_THRESHOLD = 15
 
         const handleWheel = (e: WheelEvent) => {
-            // 항상 preventDefault → Mac 브라우저 뒤로가기/앞으로가기 방지
             e.preventDefault()
 
             const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
             wheelAccum.current += delta
 
-            // 리셋 타이머: 스크롤 멈추면 누적값 초기화
             clearTimeout(wheelTimer.current)
             wheelTimer.current = setTimeout(() => { wheelAccum.current = 0 }, 150)
 
@@ -169,8 +158,7 @@ export function StampCardCarousel({
     const prevCard = currentIndex > 0 ? cards[currentIndex - 1] : null
     const nextCard = currentIndex < cards.length - 1 ? cards[currentIndex + 1] : null
 
-    // 좌우 카드 위치: 중앙 카드 기준 좌우로 배치 (PC에서도 보이게)
-    const SIDE_OFFSET = 58 // 중앙에서 좌/우 %
+    const SIDE_OFFSET = 58
 
     return (
         <div
@@ -188,7 +176,7 @@ export function StampCardCarousel({
                     height: '240px',
                 }}
             >
-                {/* 좌측 카드 (중앙 기준 왼쪽) */}
+                {/* 좌측 카드 */}
                 <AnimatePresence mode="popLayout">
                     {prevCard && (
                         <motion.div
@@ -223,15 +211,13 @@ export function StampCardCarousel({
                         onDragEnd: handleDragEnd,
                         whileDrag: { scale: 0.97 },
                     } : {})}
-                    onHoverStart={handleHoverStart}
-                    onHoverEnd={handleHoverEnd}
                     transition={springTransition}
                     role="group"
                     aria-roledescription="slide"
                     aria-label={`${currentIndex + 1} / ${cards.length}: ${currentCard?.storeName}`}
                     tabIndex={0}
                 >
-                    {/* 그림자 - 3D 컨테이너 바깥, 부드러운 디퓨즈 */}
+                    {/* 그림자 */}
                     <div
                         className="absolute -inset-2 rounded-3xl pointer-events-none"
                         style={{
@@ -244,11 +230,12 @@ export function StampCardCarousel({
                     <motion.div
                         className="relative"
                         style={{ transformStyle: 'preserve-3d' }}
+                        initial={initialFlipped ? { rotateY: 180 } : undefined}
                         animate={{ rotateY: isFlipped ? 180 : 0 }}
                         transition={flipTransition}
                         onClick={handleCenterClick}
                     >
-                        {/* 불투명 백킹: 사이드 카드가 비치는 것 차단 (앞면용/뒷면용) */}
+                        {/* 불투명 백킹 */}
                         <div
                             className="absolute inset-0 rounded-2xl bg-white"
                             style={{ transform: 'translateZ(-1px)', backfaceVisibility: 'hidden' }}
@@ -271,12 +258,17 @@ export function StampCardCarousel({
                                 transform: 'rotateY(180deg)',
                             }}
                         >
-                            <StampCardBack card={currentCard} />
+                            <StampCardBack
+                                card={currentCard}
+                                onStampRequest={() => onStampRequest?.(currentCard)}
+                                animatingStampIndex={animatingStampIndex}
+                                onAnimationComplete={onAnimationComplete}
+                            />
                         </div>
                     </motion.div>
                 </motion.div>
 
-                {/* 우측 카드 (중앙 기준 오른쪽) */}
+                {/* 우측 카드 */}
                 <AnimatePresence mode="popLayout">
                     {nextCard && (
                         <motion.div
@@ -300,12 +292,10 @@ export function StampCardCarousel({
                 </AnimatePresence>
             </div>
 
-            {/* 카드 정보: 가게 이름만 + 모바일만 버튼 */}
+            {/* 카드 정보: 가게 이름만 */}
             {currentCard && (
                 <CardInfoPanel
                     card={currentCard}
-                    onStampClick={() => onCardSelect(currentCard)}
-                    showButton={isTouchDevice}
                     direction={slideDirection}
                     className="mt-5"
                 />

--- a/frontend/src/features/wallet/pages/WalletPage.tsx
+++ b/frontend/src/features/wallet/pages/WalletPage.tsx
@@ -1,10 +1,11 @@
 /**
  * WalletPage 컴포넌트
  * 스탬프 카드 캐러셀이 포함된 메인 지갑 뷰
+ * 적립 승인 후 돌아오면 자동 뒤집기 + 도장 애니메이션 재생
  */
 
-import { useEffect, useMemo } from 'react';
-import { useOutletContext } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useOutletContext, useLocation } from 'react-router-dom';
 import { Loader2, AlertCircle } from 'lucide-react';
 import { WalletHeader } from '../components/WalletHeader';
 import { StampCardCarousel } from '../components/StampCardCarousel';
@@ -18,11 +19,32 @@ interface CustomerLayoutContext {
   setCurrentStoreId: (storeId: number | undefined) => void;
 }
 
+interface WalletLocationState {
+  stampJustAdded?: boolean;
+  animateStampIndex?: number;
+  stampedCardId?: string;
+}
+
 export function WalletPage() {
   const { storeId, customerNavigate } = useCustomerNavigate();
   const { setIsMenuOpen, setCurrentStoreId } = useOutletContext<CustomerLayoutContext>();
+  const location = useLocation();
   const storeIdNum = storeId ? Number(storeId) : undefined;
   const { data: storeSummary } = useStoreSummary(storeIdNum);
+
+  // Read navigation state for animation trigger
+  const locationState = location.state as WalletLocationState | null;
+  const [animatingStampIndex, setAnimatingStampIndex] = useState<number | undefined>(
+    locationState?.stampJustAdded ? locationState.animateStampIndex : undefined,
+  );
+  const [initialFlipped] = useState(() => locationState?.stampJustAdded === true);
+
+  // Clear navigation state to prevent re-animation on refresh
+  useEffect(() => {
+    if (locationState?.stampJustAdded) {
+      window.history.replaceState({}, '');
+    }
+  }, [locationState?.stampJustAdded]);
 
   // API Hook - JWT identifies the customer, storeId scopes the store
   const { data: walletData, isLoading, error, refetch } = useWalletStampCards(storeIdNum);
@@ -88,24 +110,32 @@ export function WalletPage() {
     return mapped;
   }, [walletData?.stampCards, storeSummary, storeIdNum]);
 
-  // 첫 번째 카드의 storeId로 초기화
+  // 적립된 카드의 초기 캐러셀 인덱스 계산
+  const stampedCardId = locationState?.stampedCardId;
+  const initialCardIndex = useMemo(() => {
+    if (!stampedCardId || cards.length === 0) return 0;
+    const idx = cards.findIndex((c) => c.id === stampedCardId);
+    return idx >= 0 ? idx : 0;
+  }, [cards, stampedCardId]);
+
+  // 첫 번째 카드의 storeId로 초기화 (또는 적립된 카드의 storeId)
   useEffect(() => {
     if (cards.length > 0) {
-      setCurrentStoreId(cards[0].storeId);
+      const startCard = cards[initialCardIndex] ?? cards[0];
+      setCurrentStoreId(startCard.storeId);
     }
-  }, [cards, setCurrentStoreId]);
+  }, [cards, initialCardIndex, setCurrentStoreId]);
 
   const handleCardChange = (card: StampCard) => {
     setCurrentStoreId(card.storeId);
   };
 
-  const handleCardSelect = (card: StampCard) => {
-    const isComplete = card.current >= card.max;
-    if (isComplete) {
-      customerNavigate('/redeems');
-    } else {
-      customerNavigate(`/wallet/${card.id}/stamp`);
-    }
+  const handleStampRequest = (card: StampCard) => {
+    customerNavigate(`/wallet/${card.id}/stamp`);
+  };
+
+  const handleAnimationComplete = () => {
+    setAnimatingStampIndex(undefined);
   };
 
   // Loading state
@@ -161,7 +191,15 @@ export function WalletPage() {
       <WalletHeader onMenuClick={() => setIsMenuOpen(true)} />
 
       <div className="flex-1 flex flex-col justify-center pb-8">
-        <StampCardCarousel cards={cards} onCardSelect={handleCardSelect} onCardChange={handleCardChange} />
+        <StampCardCarousel
+          cards={cards}
+          initialIndex={initialCardIndex}
+          onCardChange={handleCardChange}
+          onStampRequest={handleStampRequest}
+          initialFlipped={initialFlipped}
+          animatingStampIndex={animatingStampIndex}
+          onAnimationComplete={handleAnimationComplete}
+        />
       </div>
     </div>
   );

--- a/frontend/src/hooks/useCustomerNavigate.ts
+++ b/frontend/src/hooks/useCustomerNavigate.ts
@@ -27,13 +27,10 @@ export function useCustomerNavigate() {
   const storeId = urlStoreId || sessionStorage.getItem(STORE_ID_KEY) || undefined;
 
   const customerNavigate = useCallback(
-    (path: string) => {
+    (path: string, options?: { state?: unknown; replace?: boolean }) => {
       const p = path.startsWith('/') ? path : `/${path}`;
-      if (urlStoreId) {
-        navigate(`/stores/${urlStoreId}/customer${p}`);
-      } else {
-        navigate(`/customer${p}`);
-      }
+      const to = urlStoreId ? `/stores/${urlStoreId}/customer${p}` : `/customer${p}`;
+      navigate(to, options);
     },
     [navigate, urlStoreId],
   );


### PR DESCRIPTION
## 📌 작업 내용 요약
- 카드 뒷면 그리드의 다음 빈 슬롯에 적립 요청 버튼(+ 아이콘, 펄스) 배치
- 승인 후 지갑 복귀 시 실물 도장 내려찍기 애니메이션 재생
- PC/모바일 플립 동작 통일 (hover 플립 제거, 클릭/탭 = 플립 토글)
- CardInfoPanel 하단 버튼 제거, 매장명만 유지
- useCustomerNavigate에 state/replace 옵션 지원 추가
- 적립된 카드 위치에서 캐러셀 시작되도록 initialIndex 지원
- handleViewNewCard 존재하지 않는 라우트(/wallet/:cardId) 수정
