### PR TITLE
feat: 스탬프 카드 캐러셀 UX 개선 - scroll-snap 전환 + 카드스톡 질감 + 위치 기억

### DIFF
--- a/frontend/src/assets/styles/index.css
+++ b/frontend/src/assets/styles/index.css
@@ -344,3 +344,39 @@ body {
   pointer-events: none;
   border-radius: inherit;
 }
+
+/* Cardstock texture - real cafe stamp card feel */
+.texture-cardstock::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='paper'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='5' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23paper)'/%3E%3C/svg%3E");
+  opacity: 0.06;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 1;
+}
+
+/* Cardstock edge thickness - bottom/right shadow for physical depth */
+.shadow-cardstock {
+  box-shadow:
+    0 2px 4px -1px rgba(0, 0, 0, 0.06),
+    0 4px 8px -2px rgba(0, 0, 0, 0.08),
+    0 8px 16px -4px rgba(0, 0, 0, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.04);
+}
+
+/* White cardstock (back side) - subtle paper grain */
+.texture-cardstock-white::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='paper'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='5' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23paper)'/%3E%3C/svg%3E");
+  opacity: 0.04;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 1;
+}

--- a/frontend/src/features/wallet/components/StampCardBack.tsx
+++ b/frontend/src/features/wallet/components/StampCardBack.tsx
@@ -39,12 +39,18 @@ export function StampCardBack({ card, className, onStampRequest, animatingStampI
         <div
             className={cn(
                 'w-full aspect-[1.58/1] rounded-2xl overflow-hidden relative',
-                'bg-white select-none flex flex-col',
+                'bg-white select-none flex flex-col texture-cardstock-white shadow-cardstock',
                 className,
             )}
         >
-            {/* 보더 */}
+            {/* 보더 + 엣지 두께감 */}
             <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-slate-200/80 pointer-events-none" />
+            <div
+                className="absolute inset-0 rounded-2xl pointer-events-none"
+                style={{
+                    boxShadow: 'inset 0 -1px 2px rgba(0,0,0,0.04), inset 0 1px 1px rgba(255,255,255,0.6)',
+                }}
+            />
 
             {/* 상단: 진행률 + 보상 */}
             <div className="px-4 pt-4 pb-2 shrink-0 flex items-center justify-between">

--- a/frontend/src/features/wallet/components/StampCardCarousel.tsx
+++ b/frontend/src/features/wallet/components/StampCardCarousel.tsx
@@ -1,14 +1,14 @@
 /**
  * StampCardCarousel 컴포넌트
- * 가로형 스탬프 카드 캐러셀 (심플 스케일 전환)
- * - 중앙 카드: 크게 표시, tap/click으로 3D 플립
- * - 좌우 카드: 중앙 기준 좌우에 작게 + 반투명 (PC/모바일 모두)
- * - 스와이프(모바일) / 휠 스크롤(PC)로 전환
- * - 그리드 내 적립 버튼으로 적립 요청
+ * CSS scroll-snap 기반 가로 캐러셀
+ * - 모바일: 네이티브 터치 스크롤 (관성, 러버밴드 자동)
+ * - PC: 휠/트랙패드로 카드 단위 이동
+ * - 스크롤 중 카드 스케일/투명도 자연스럽게 변화
+ * - 센터 카드 탭으로 3D 플립 (앞면 ↔ 뒷면)
  */
 
 import { useCallback, useState, useEffect, useRef } from 'react'
-import { motion, AnimatePresence, type PanInfo } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import type { StampCard } from '@/types/domain'
 import { StampCardFront } from './StampCardFront'
@@ -26,13 +26,9 @@ interface StampCardCarouselProps {
     className?: string
 }
 
-const DRAG_THRESHOLD = 50
-
-const springTransition = {
-    type: 'spring' as const,
-    stiffness: 300,
-    damping: 28,
-}
+const CARD_GAP = 16
+const CARD_WIDTH_RATIO = 0.78
+const CARD_MAX_WIDTH = 340
 
 const flipTransition = {
     type: 'spring' as const,
@@ -61,84 +57,153 @@ export function StampCardCarousel({
     const [isFlipped, setIsFlipped] = useState(initialFlipped ?? false)
     const [slideDirection, setSlideDirection] = useState<1 | -1>(1)
     const isTouchDevice = useIsTouchDevice()
+
+    const scrollRef = useRef<HTMLDivElement>(null)
+    const cardRefs = useRef<(HTMLDivElement | null)[]>([])
+    const scaleRefs = useRef<(HTMLDivElement | null)[]>([])
+    const currentIndexRef = useRef(currentIndex)
+    const isScrolling = useRef(false)
+    const scrollTimeout = useRef<ReturnType<typeof setTimeout>>()
     const wheelAccum = useRef(0)
     const wheelTimer = useRef<ReturnType<typeof setTimeout>>()
-    const carouselRef = useRef<HTMLDivElement>(null)
+
+    const containerWidth = typeof window !== 'undefined' ? window.innerWidth : 375
+    const cardWidth = Math.min(containerWidth * CARD_WIDTH_RATIO, CARD_MAX_WIDTH)
+    const cardSpacing = cardWidth + CARD_GAP
+    const sidePadding = (containerWidth - cardWidth) / 2
+
+    currentIndexRef.current = currentIndex
+
+    // ── 카드로 스크롤 ──
+
+    const scrollToCard = useCallback(
+        (index: number, behavior: ScrollBehavior = 'smooth') => {
+            const container = scrollRef.current
+            if (!container) return
+            const clamped = Math.max(0, Math.min(index, cards.length - 1))
+            container.scrollTo({ left: clamped * cardSpacing, behavior })
+        },
+        [cards.length, cardSpacing],
+    )
 
     const goTo = useCallback(
         (index: number, direction?: 1 | -1) => {
             const clamped = Math.max(0, Math.min(index, cards.length - 1))
-            if (clamped !== currentIndex) {
-                setSlideDirection(direction ?? (clamped > currentIndex ? 1 : -1))
-                setCurrentIndex(clamped)
-                setIsFlipped(false)
-                onCardChange?.(cards[clamped])
+            if (clamped !== currentIndexRef.current) {
+                setSlideDirection(direction ?? (clamped > currentIndexRef.current ? 1 : -1))
+                scrollToCard(clamped)
             }
         },
-        [cards, currentIndex, onCardChange],
+        [cards.length, scrollToCard],
     )
 
-    const handleDragEnd = useCallback(
-        (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
-            if (Math.abs(info.offset.x) > DRAG_THRESHOLD) {
-                if (info.offset.x > 0 && currentIndex > 0) {
-                    goTo(currentIndex - 1, -1)
-                } else if (info.offset.x < 0 && currentIndex < cards.length - 1) {
-                    goTo(currentIndex + 1, 1)
-                }
+    // ── 스크롤 핸들러: 스케일/투명도 + 현재 인덱스 ──
+
+    const handleScroll = useCallback(() => {
+        const container = scrollRef.current
+        if (!container) return
+
+        const containerRect = container.getBoundingClientRect()
+        const viewportCenterX = containerRect.left + containerRect.width / 2
+
+        isScrolling.current = true
+        clearTimeout(scrollTimeout.current)
+        scrollTimeout.current = setTimeout(() => {
+            isScrolling.current = false
+        }, 150)
+
+        let nearestIndex = 0
+        let nearestDist = Infinity
+
+        cards.forEach((_, i) => {
+            const cardEl = cardRefs.current[i]
+            const scaleEl = scaleRefs.current[i]
+            if (!cardEl || !scaleEl) return
+
+            const cardRect = cardEl.getBoundingClientRect()
+            const cardCenterX = cardRect.left + cardRect.width / 2
+            const distance = Math.abs(viewportCenterX - cardCenterX)
+            const normalized = Math.min(distance / cardSpacing, 1.5)
+
+            const scale = 1 - Math.min(normalized, 1) * 0.15
+            const opacity = 1 - Math.min(normalized, 1) * 0.5
+
+            scaleEl.style.transform = `scale(${scale})`
+            scaleEl.style.opacity = `${opacity}`
+
+            if (distance < nearestDist) {
+                nearestDist = distance
+                nearestIndex = i
             }
-        },
-        [currentIndex, cards.length, goTo],
-    )
+        })
 
-    // 클릭/탭: 항상 플립 토글
-    const handleCenterClick = useCallback(() => {
-        setIsFlipped((prev) => !prev)
+        if (nearestIndex !== currentIndexRef.current) {
+            const prev = currentIndexRef.current
+            currentIndexRef.current = nearestIndex
+            setCurrentIndex(nearestIndex)
+            setSlideDirection(nearestIndex > prev ? 1 : -1)
+            setIsFlipped(false)
+            onCardChange?.(cards[nearestIndex])
+        }
+    }, [cards, cardSpacing, onCardChange])
+
+    // 스크롤 리스너
+    useEffect(() => {
+        const container = scrollRef.current
+        if (!container) return
+        container.addEventListener('scroll', handleScroll, { passive: true })
+        return () => container.removeEventListener('scroll', handleScroll)
+    }, [handleScroll])
+
+    // 초기 위치 + 스케일
+    useEffect(() => {
+        scrollToCard(initialIndex, 'auto')
+        requestAnimationFrame(handleScroll)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    // PC: 가로 스크롤(휠/트랙패드)로 캐러셀 전환
+    // ── PC: 휠/트랙패드 → 카드 단위 이동 ──
+
     useEffect(() => {
-        const el = carouselRef.current
-        if (!el || isTouchDevice) return
+        const container = scrollRef.current
+        if (!container || isTouchDevice) return
 
         const ACCUM_THRESHOLD = 15
 
         const handleWheel = (e: WheelEvent) => {
             e.preventDefault()
-
             const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
             wheelAccum.current += delta
 
             clearTimeout(wheelTimer.current)
-            wheelTimer.current = setTimeout(() => { wheelAccum.current = 0 }, 150)
+            wheelTimer.current = setTimeout(() => {
+                wheelAccum.current = 0
+            }, 150)
 
             if (Math.abs(wheelAccum.current) >= ACCUM_THRESHOLD) {
                 const dir = wheelAccum.current > 0 ? 1 : -1
                 wheelAccum.current = 0
-                if (dir > 0) {
-                    goTo(currentIndex + 1, 1)
-                } else {
-                    goTo(currentIndex - 1, -1)
-                }
+                goTo(currentIndexRef.current + dir, dir as 1 | -1)
             }
         }
 
-        el.addEventListener('wheel', handleWheel, { passive: false })
+        container.addEventListener('wheel', handleWheel, { passive: false })
         return () => {
-            el.removeEventListener('wheel', handleWheel)
+            container.removeEventListener('wheel', handleWheel)
             clearTimeout(wheelTimer.current)
         }
-    }, [currentIndex, goTo, isTouchDevice])
+    }, [goTo, isTouchDevice])
 
-    // 키보드 네비게이션
+    // ── 키보드 ──
+
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             switch (e.key) {
                 case 'ArrowLeft':
-                    goTo(currentIndex - 1)
+                    goTo(currentIndexRef.current - 1)
                     break
                 case 'ArrowRight':
-                    goTo(currentIndex + 1)
+                    goTo(currentIndexRef.current + 1)
                     break
                 case 'Enter':
                 case ' ':
@@ -152,13 +217,23 @@ export function StampCardCarousel({
         }
         window.addEventListener('keydown', handleKeyDown)
         return () => window.removeEventListener('keydown', handleKeyDown)
-    }, [currentIndex, goTo])
+    }, [goTo])
+
+    // ── 카드 클릭/탭 ──
+
+    const handleCardClick = useCallback(
+        (index: number) => {
+            if (isScrolling.current) return
+            if (index === currentIndexRef.current) {
+                setIsFlipped((prev) => !prev)
+            } else {
+                goTo(index)
+            }
+        },
+        [goTo],
+    )
 
     const currentCard = cards[currentIndex]
-    const prevCard = currentIndex > 0 ? cards[currentIndex - 1] : null
-    const nextCard = currentIndex < cards.length - 1 ? cards[currentIndex + 1] : null
-
-    const SIDE_OFFSET = 58
 
     return (
         <div
@@ -167,139 +242,113 @@ export function StampCardCarousel({
             aria-label="스탬프 카드 캐러셀"
             aria-roledescription="carousel"
         >
-            {/* 캐러셀 영역 - 100vw */}
+            {/* 스크롤 캐러셀 — 네이티브 터치 스크롤 + snap */}
             <div
-                ref={carouselRef}
-                className="relative w-screen overflow-hidden flex items-center justify-center"
-                style={{
-                    perspective: '1200px',
-                    height: '240px',
-                }}
+                ref={scrollRef}
+                className="flex overflow-x-auto snap-x snap-mandatory no-scrollbar items-center w-screen"
+                style={{ height: '240px' }}
             >
-                {/* 좌측 카드 */}
-                <AnimatePresence mode="popLayout">
-                    {prevCard && (
-                        <motion.div
-                            key={`prev-${prevCard.id}`}
-                            className="absolute cursor-pointer"
-                            style={{
-                                width: '70%',
-                                maxWidth: 300,
-                                zIndex: 1,
-                                left: '50%',
-                            }}
-                            initial={{ opacity: 0, x: `-${SIDE_OFFSET + 40}%` }}
-                            animate={{ opacity: 0.5, x: `-${SIDE_OFFSET + 50}%`, scale: 0.8 }}
-                            exit={{ opacity: 0, x: `-${SIDE_OFFSET + 40}%` }}
-                            transition={springTransition}
-                            onClick={() => goTo(currentIndex - 1)}
-                        >
-                            <StampCardFront card={prevCard} />
-                        </motion.div>
-                    )}
-                </AnimatePresence>
+                {/* 좌측 여백 (첫 카드 센터링) */}
+                <div className="flex-shrink-0" style={{ width: sidePadding }} />
 
-                {/* 중앙 카드 (3D 플립) */}
-                <motion.div
-                    className="relative cursor-pointer isolate"
-                    style={{ width: '78%', maxWidth: 340, zIndex: 10 }}
-                    {...(isTouchDevice ? {
-                        drag: 'x' as const,
-                        dragConstraints: { left: 0, right: 0 },
-                        dragElastic: 0.15,
-                        dragMomentum: false,
-                        onDragEnd: handleDragEnd,
-                        whileDrag: { scale: 0.97 },
-                    } : {})}
-                    transition={springTransition}
-                    role="group"
-                    aria-roledescription="slide"
-                    aria-label={`${currentIndex + 1} / ${cards.length}: ${currentCard?.storeName}`}
-                    tabIndex={0}
-                >
-                    {/* 그림자 */}
+                {cards.map((card, i) => (
                     <div
-                        className="absolute -inset-2 rounded-3xl pointer-events-none"
-                        style={{
-                            background: 'radial-gradient(ellipse at 50% 60%, rgba(0,0,0,0.12) 0%, transparent 70%)',
-                            filter: 'blur(12px)',
-                            transform: 'translateY(8px)',
+                        key={card.id}
+                        ref={(el) => {
+                            cardRefs.current[i] = el
                         }}
-                    />
-
-                    <motion.div
-                        className="relative"
-                        style={{ transformStyle: 'preserve-3d' }}
-                        initial={initialFlipped ? { rotateY: 180 } : undefined}
-                        animate={{ rotateY: isFlipped ? 180 : 0 }}
-                        transition={flipTransition}
-                        onClick={handleCenterClick}
+                        className="snap-center flex-shrink-0"
+                        style={{
+                            width: cardWidth,
+                            marginRight: i < cards.length - 1 ? CARD_GAP : 0,
+                        }}
                     >
-                        {/* 불투명 백킹 */}
+                        {/* 스케일/투명도 래퍼 (스크롤 위치 기반 DOM 직접 조작) */}
                         <div
-                            className="absolute inset-0 rounded-2xl bg-white"
-                            style={{ transform: 'translateZ(-1px)', backfaceVisibility: 'hidden' }}
-                        />
-                        <div
-                            className="absolute inset-0 rounded-2xl bg-white"
-                            style={{ transform: 'rotateY(180deg) translateZ(-1px)', backfaceVisibility: 'hidden' }}
-                        />
-
-                        {/* 앞면 */}
-                        <div style={{ backfaceVisibility: 'hidden' }}>
-                            <StampCardFront card={currentCard} />
-                        </div>
-
-                        {/* 뒷면 */}
-                        <div
-                            className="absolute inset-0"
+                            ref={(el) => {
+                                scaleRefs.current[i] = el
+                            }}
+                            className="will-change-transform"
                             style={{
-                                backfaceVisibility: 'hidden',
-                                transform: 'rotateY(180deg)',
+                                transformOrigin: 'center center',
+                                transformStyle: 'preserve-3d',
+                                transition: 'none',
                             }}
                         >
-                            <StampCardBack
-                                card={currentCard}
-                                onStampRequest={() => onStampRequest?.(currentCard)}
-                                animatingStampIndex={animatingStampIndex}
-                                onAnimationComplete={onAnimationComplete}
-                            />
-                        </div>
-                    </motion.div>
-                </motion.div>
+                            <div className="relative" style={{ perspective: '1200px' }}>
+                                {/* 그림자 */}
+                                <div
+                                    className="absolute -inset-2 rounded-3xl pointer-events-none"
+                                    style={{
+                                        background:
+                                            'radial-gradient(ellipse at 50% 60%, rgba(0,0,0,0.12) 0%, transparent 70%)',
+                                        filter: 'blur(12px)',
+                                        transform: 'translateY(8px)',
+                                    }}
+                                />
 
-                {/* 우측 카드 */}
-                <AnimatePresence mode="popLayout">
-                    {nextCard && (
-                        <motion.div
-                            key={`next-${nextCard.id}`}
-                            className="absolute cursor-pointer"
-                            style={{
-                                width: '70%',
-                                maxWidth: 300,
-                                zIndex: 1,
-                                left: '50%',
-                            }}
-                            initial={{ opacity: 0, x: `${SIDE_OFFSET - 10}%` }}
-                            animate={{ opacity: 0.5, x: `${SIDE_OFFSET - 50}%`, scale: 0.8 }}
-                            exit={{ opacity: 0, x: `${SIDE_OFFSET - 10}%` }}
-                            transition={springTransition}
-                            onClick={() => goTo(currentIndex + 1)}
-                        >
-                            <StampCardFront card={nextCard} />
-                        </motion.div>
-                    )}
-                </AnimatePresence>
+                                {/* 3D 플립 */}
+                                <motion.div
+                                    className="relative cursor-pointer"
+                                    style={{ transformStyle: 'preserve-3d' }}
+                                    animate={{ rotateY: isFlipped && i === currentIndex ? 180 : 0 }}
+                                    transition={flipTransition}
+                                    onClick={() => handleCardClick(i)}
+                                    role="group"
+                                    aria-roledescription="slide"
+                                    aria-label={`${i + 1} / ${cards.length}: ${card.storeName}`}
+                                    tabIndex={i === currentIndex ? 0 : -1}
+                                >
+                                    {/* 불투명 백킹 */}
+                                    <div
+                                        className="absolute inset-0 rounded-2xl bg-white"
+                                        style={{
+                                            transform: 'translateZ(-1px)',
+                                            backfaceVisibility: 'hidden',
+                                        }}
+                                    />
+                                    <div
+                                        className="absolute inset-0 rounded-2xl bg-white"
+                                        style={{
+                                            transform: 'rotateY(180deg) translateZ(-1px)',
+                                            backfaceVisibility: 'hidden',
+                                        }}
+                                    />
+
+                                    {/* 앞면 */}
+                                    <div style={{ backfaceVisibility: 'hidden' }}>
+                                        <StampCardFront card={card} />
+                                    </div>
+
+                                    {/* 뒷면 */}
+                                    <div
+                                        className="absolute inset-0"
+                                        style={{
+                                            backfaceVisibility: 'hidden',
+                                            transform: 'rotateY(180deg)',
+                                        }}
+                                    >
+                                        <StampCardBack
+                                            card={card}
+                                            onStampRequest={
+                                                i === currentIndex ? () => onStampRequest?.(card) : undefined
+                                            }
+                                            animatingStampIndex={i === currentIndex ? animatingStampIndex : undefined}
+                                            onAnimationComplete={i === currentIndex ? onAnimationComplete : undefined}
+                                        />
+                                    </div>
+                                </motion.div>
+                            </div>
+                        </div>
+                    </div>
+                ))}
+
+                {/* 우측 여백 (마지막 카드 센터링) */}
+                <div className="flex-shrink-0" style={{ width: sidePadding }} />
             </div>
 
-            {/* 카드 정보: 가게 이름만 */}
-            {currentCard && (
-                <CardInfoPanel
-                    card={currentCard}
-                    direction={slideDirection}
-                    className="mt-5"
-                />
-            )}
+            {/* 카드 정보 */}
+            {currentCard && <CardInfoPanel card={currentCard} direction={slideDirection} className="mt-5" />}
         </div>
     )
 }

--- a/frontend/src/features/wallet/components/StampCardFront.tsx
+++ b/frontend/src/features/wallet/components/StampCardFront.tsx
@@ -22,7 +22,7 @@ export function StampCardFront({ card, className }: StampCardFrontProps) {
     <div
       className={cn(
         "w-full aspect-[1.58/1] rounded-2xl overflow-hidden relative",
-        "select-none",
+        "select-none texture-cardstock shadow-cardstock",
         !hasBackgroundImage && "bg-linear-to-br",
         !hasBackgroundImage && bgGradient,
         className,
@@ -70,19 +70,23 @@ export function StampCardFront({ card, className }: StampCardFrontProps) {
 
           {/* 하단 그라데이션 깊이감 */}
           <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-t from-black/8 to-transparent" />
+
+          {/* 매트 코팅 오버레이 - 채도 약간 낮춰 카드스톡 느낌 */}
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{ background: 'rgba(0,0,0,0.03)', mixBlendMode: 'saturation' }}
+          />
         </>
       )}
 
-      {/* 미세한 노이즈 텍스처 오버레이 */}
+      {/* 인너 보더 하이라이트 - 카드 엣지 두께감 */}
+      <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/20 pointer-events-none" />
       <div
-        className="absolute inset-0 opacity-[0.03] mix-blend-overlay pointer-events-none"
+        className="absolute inset-0 rounded-2xl pointer-events-none"
         style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+          boxShadow: 'inset 0 -1px 2px rgba(0,0,0,0.08), inset 0 1px 1px rgba(255,255,255,0.15)',
         }}
       />
-
-      {/* 인너 보더 하이라이트 */}
-      <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/15 pointer-events-none" />
     </div>
   );
 }

--- a/frontend/src/features/wallet/pages/WalletPage.tsx
+++ b/frontend/src/features/wallet/pages/WalletPage.tsx
@@ -111,11 +111,20 @@ export function WalletPage() {
   }, [walletData?.stampCards, storeSummary, storeIdNum]);
 
   // 적립된 카드의 초기 캐러셀 인덱스 계산
+  // 우선순위: stampedCardId (적립 후 복귀) > sessionStorage (탭 이동 후 복귀) > 0
   const stampedCardId = locationState?.stampedCardId;
   const initialCardIndex = useMemo(() => {
-    if (!stampedCardId || cards.length === 0) return 0;
-    const idx = cards.findIndex((c) => c.id === stampedCardId);
-    return idx >= 0 ? idx : 0;
+    if (cards.length === 0) return 0;
+    if (stampedCardId) {
+      const idx = cards.findIndex((c) => c.id === stampedCardId);
+      if (idx >= 0) return idx;
+    }
+    const lastViewedCardId = sessionStorage.getItem('wallet_lastViewedCardId');
+    if (lastViewedCardId) {
+      const idx = cards.findIndex((c) => c.id === lastViewedCardId);
+      if (idx >= 0) return idx;
+    }
+    return 0;
   }, [cards, stampedCardId]);
 
   // 첫 번째 카드의 storeId로 초기화 (또는 적립된 카드의 storeId)
@@ -128,6 +137,7 @@ export function WalletPage() {
 
   const handleCardChange = (card: StampCard) => {
     setCurrentStoreId(card.storeId);
+    sessionStorage.setItem('wallet_lastViewedCardId', card.id);
   };
 
   const handleStampRequest = (card: StampCard) => {


### PR DESCRIPTION
- 캐러셀을 CSS scroll-snap 기반으로 재구현 (모바일 네이티브 터치 + PC 휠)
- 카드스톡 질감/그림자 CSS 유틸리티 추가 (texture-cardstock, shadow-cardstock)
- 탭 이동 후 복귀 시 마지막으로 본 카드 위치 유지 (sessionStorage)