### PR TITLE
QA : 회원가입 전화번호 중복 메시지 노출 타이밍 통일

### DIFF
--- a/frontend/src/features/auth/components/CustomerSignupForm.tsx
+++ b/frontend/src/features/auth/components/CustomerSignupForm.tsx
@@ -86,7 +86,9 @@ export function CustomerSignupForm() {
         return;
       }
     } catch {
-      // 네트워크 에러 시 서버에서 최종 차단하므로 진행 허용
+      setError("전화번호 확인에 실패했습니다. 다시 시도해주세요.");
+      setIsCheckingPhone(false);
+      return;
     }
     setIsCheckingPhone(false);
 
@@ -150,8 +152,11 @@ export function CustomerSignupForm() {
                   const nameFieldError = fieldErrors.find(e => e.field === 'name');
                   setNameError(nameFieldError?.message ?? "이름에는 숫자를 입력할 수 없어요.");
                   setStep("input");
+                } else if (errorCode === 'WALLET_001') {
+                  setPhoneError("이미 등록된 번호입니다");
+                  setStep("input");
                 } else {
-                  setError("이미 등록된 번호입니다.");
+                  setError("회원가입에 실패했습니다. 다시 시도해주세요.");
                 }
               },
             }


### PR DESCRIPTION

## 🔗 관련 이슈

Closes #161 

## 📌 작업 내용 요약
 회원가입 시 "이미 등록된 번호입니다" 메시지가 1단계 또는 2단계에서 불일치하게 노출되는 문제 수정                          

## 🚀 변경 사항
                                                                                                                            
  - checkPhone 네트워크 에러 시 step2로 넘기지 않고 차단                                         
  - walletRegister 에러에서 WALLET_001 명시 매칭 → step1 복귀 (번호 변경 가능)
  - 기타 에러 fallback을 "이미 등록된 번호입니다" → "회원가입에 실패했습니다"로 변경

