### PR TITLE
fix: 프로덕션 OAuth2 redirect-uri 및 CD 타임아웃 수정

### DIFF
--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -25,19 +25,19 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile, email
-            redirect-uri: "{baseUrl}/api/public/oauth2/callback/{registrationId}"
+            redirect-uri: "${FRONTEND_URL}/api/public/oauth2/callback/{registrationId}"
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/api/public/oauth2/callback/{registrationId}"
+            redirect-uri: "${FRONTEND_URL}/api/public/oauth2/callback/{registrationId}"
             client-authentication-method: client_secret_post
             scope: profile_nickname
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/api/public/oauth2/callback/{registrationId}"
+            redirect-uri: "${FRONTEND_URL}/api/public/oauth2/callback/{registrationId}"
             client-authentication-method: client_secret_post
             scope: name, email
         provider:


### PR DESCRIPTION
## Summary
- OAuth2 redirect-uri를 `{baseUrl}` → `${FRONTEND_URL}` 기반으로 변경 (프록시 뒤에서 내부 주소로 해석되는 문제 수정)
- Backend CD SSM wait 타임아웃을 100s → 300s로 증가 (배포 스크립트 실행 시간 고려)

## Test plan
- [ ] Backend CD 배포 성공 확인
- [ ] Google OAuth 로그인 redirect URI 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)