### PR TITLE
fix: OAuth2 기존 유저 로그인 토큰 미저장 및 redirect-uri 수정

### DIFF
--- a/frontend/src/features/auth/components/OAuthCallbackPage.tsx
+++ b/frontend/src/features/auth/components/OAuthCallbackPage.tsx
@@ -11,6 +11,7 @@ import { Loader2 } from 'lucide-react';
 import { useExchangeOAuthCode } from '../hooks/useOAuth';
 import { getOAuthState, clearOAuthState } from '../utils/oauthUrl';
 import { useAuth } from '@/app/providers/AuthProvider';
+import { setAuthToken, setUserInfo } from '@/lib/api/tokenManager';
 import { kkookkToast } from '@/components/ui/Toast';
 
 export function OAuthCallbackPage() {
@@ -70,7 +71,18 @@ export function OAuthCallbackPage() {
           return;
         }
 
-        // Existing user → logged in
+        // Existing user → save tokens and log in
+        const tokenType = role === 'OWNER' ? 'owner' : 'customer';
+        if (response.accessToken && response.refreshToken) {
+          setAuthToken(response.accessToken, response.refreshToken, tokenType);
+          setUserInfo({
+            id: response.id!,
+            name: response.name,
+            nickname: response.nickname,
+            email: response.email,
+            phone: response.phone,
+          });
+        }
         refreshAuthState();
 
         if (role === 'CUSTOMER') {


### PR DESCRIPTION
## Summary
- 기존 유저 OAuth 로그인 시 accessToken/refreshToken을 localStorage에 저장하지 않아 카드가 안 보이는 버그 수정
- 프로덕션 OAuth2 redirect-uri를 `{baseUrl}` → `${FRONTEND_URL}` 기반으로 변경 (프록시 뒤 내부 주소 해석 문제)

## Test plan
- [ ] 기존 유저 Google OAuth 로그인 → 지갑 페이지에서 카드 정상 표시 확인
- [ ] 신규 유저 가입 플로우 정상 동작 확인
- [ ] 프로덕션 배포 후 OAuth redirect URI 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)