### PR TITLE
fix: OAuth 로그인 후 스탬프 카드 미표시 버그 수정

### DIFF
--- a/frontend/src/features/auth/components/OAuthCallbackPage.tsx
+++ b/frontend/src/features/auth/components/OAuthCallbackPage.tsx
@@ -12,6 +12,7 @@ import { useExchangeOAuthCode } from '../hooks/useOAuth';
 import { getOAuthState, clearOAuthState } from '../utils/oauthUrl';
 import { useAuth } from '@/app/providers/AuthProvider';
 import { setAuthToken, setUserInfo } from '@/lib/api/tokenManager';
+import { saveOriginStoreId } from '@/hooks/useCustomerNavigate';
 import { kkookkToast } from '@/components/ui/Toast';
 
 export function OAuthCallbackPage() {
@@ -87,7 +88,7 @@ export function OAuthCallbackPage() {
 
         if (role === 'CUSTOMER') {
           if (storeId) {
-            sessionStorage.setItem('origin_store_id', storeId);
+            saveOriginStoreId(storeId);
           }
           navigate('/customer/wallet', { replace: true });
         } else if (role === 'OWNER') {


### PR DESCRIPTION
## Summary
- OAuth 기존 유저 로그인 시 `setAuthToken()` 미호출로 토큰이 저장되지 않던 버그 수정
- `OAuthCallbackPage`에서 storeId를 `origin_store_id` 키로 저장하고 `useCustomerNavigate`는 `customer_storeId`로 읽는 키 불일치 수정 → wallet 페이지에서 스탬프 카드 API 호출이 안 되던 문제 해결
- 프로덕션 OAuth2 redirect-uri를 `{baseUrl}` → `${FRONTEND_URL}` 기반으로 변경 (CloudFront 프록시 환경 대응)

## Test plan
- [ ] 고객 OAuth 로그인 (신규 유저) → 가입 폼 표시 → 완료 → 스탬프 카드 표시 확인
- [ ] 고객 OAuth 로그인 (기존 유저) → 바로 wallet 이동 → 스탬프 카드 표시 확인
- [ ] Owner OAuth 로그인 정상 동작 확인
- [ ] 프로덕션 환경에서 OAuth redirect-uri 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)