### PR TITLE
feat: ArchUnit + Checkstyle로 AI 코드 품질 자동 검증 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 }

--- a/backend/config/checkstyle/checkstyle.xml
+++ b/backend/config/checkstyle/checkstyle.xml
@@ -141,6 +141,17 @@
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 
+        <!--
+            jakarta.transaction.Transactional 사용 금지.
+            Spring의 @Transactional 옵션(readOnly, rollbackFor, propagation)을 사용하려면
+            org.springframework.transaction.annotation.Transactional 을 import해야 한다.
+        -->
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="jakarta.transaction"/>
+            <message key="import.illegal"
+                     value="jakarta.transaction.Transactional 대신 org.springframework.transaction.annotation.Transactional을 사용하세요."/>
+        </module>
+
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>

--- a/backend/config/checkstyle/suppressions.xml
+++ b/backend/config/checkstyle/suppressions.xml
@@ -17,4 +17,8 @@
     <!-- Suppress VariableDeclarationUsageDistance for test files (given-when-then pattern) -->
     <suppress checks="VariableDeclarationUsageDistance"
               files=".*Test\.java$"/>
+
+    <!-- ArchUnit 테스트 파일: Spotless 포맷과 Checkstyle 들여쓰기/라인길이 충돌 예외 -->
+    <suppress checks="LineLength|JavadocVariable|MissingJavadocMethod|Indentation|JavadocTagContinuationIndentation"
+              files=".*architecture.*Test\.java$"/>
 </suppressions>

--- a/backend/src/test/java/com/project/kkookk/architecture/ArchitectureTest.java
+++ b/backend/src/test/java/com/project/kkookk/architecture/ArchitectureTest.java
@@ -1,0 +1,231 @@
+package com.project.kkookk.architecture;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideOutsideOfPackages;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition;
+import jakarta.persistence.Entity;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * ArchUnit 아키텍처 규칙 테스트.
+ *
+ * <p>Claude Code가 생성한 코드를 포함해 모든 코드에 대해 아키텍처 규칙을 자동 검증한다. 테스트 실패 시 에러 메시지를 읽고 스스로 수정한다 — 교과서가 아닌
+ * 시험지.
+ */
+@AnalyzeClasses(
+        packages = "com.project.kkookk",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+class ArchitectureTest {
+
+    /**
+     * global 패키지 예외 처리.
+     *
+     * <p>global.security 안의 TokenRefreshController, RefreshTokenService, RefreshTokenRepository가 한
+     * 패키지에 공존하는 의도적 설계이므로 패키지 위치/레이어 규칙에서 제외한다.
+     */
+    private static final String GLOBAL_PKG = "com.project.kkookk.global..";
+
+    // ============================================================
+    // 1. 레이어 의존성 규칙
+    // ============================================================
+
+    /**
+     * @RestController 클래스에서 Repository 직접 주입 금지.
+     *
+     * <p>DTO factory 메서드가 Projection을 받는 패턴은 허용된다. 실제 Controller 클래스에서 Repository 빈을 주입하는 것만 금지한다.
+     */
+    @ArchTest
+    static final ArchRule CONTROLLERS_MUST_NOT_ACCESS_REPOSITORIES =
+            noClasses()
+                    .that()
+                    .areAnnotatedWith(RestController.class)
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAPackage("..repository..")
+                    .because("@RestController는 Repository를 직접 사용할 수 없습니다. Service 레이어를 통해 접근하세요.");
+
+    /** Repository → Service 역방향 참조 금지. */
+    @ArchTest
+    static final ArchRule REPOSITORIES_MUST_NOT_ACCESS_SERVICES =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..repository..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAPackage("..service..")
+                    .because("Repository → Service 역방향 의존은 허용되지 않습니다.");
+
+    // ============================================================
+    // 2. 패키지 위치 규칙  (global 패키지 및 ..config.. 패키지 제외)
+    // ============================================================
+
+    /** *Controller 클래스는 controller 패키지 안에 위치해야 한다. */
+    @ArchTest
+    static final ArchRule CONTROLLERS_RESIDE_IN_CONTROLLER_PACKAGE =
+            classes()
+                    .that()
+                    .haveSimpleNameEndingWith("Controller")
+                    .and()
+                    .resideOutsideOfPackage(GLOBAL_PKG)
+                    .should()
+                    .resideInAPackage("..controller..")
+                    .because("*Controller 클래스는 controller 패키지 안에 위치해야 합니다.");
+
+    /** *Service 클래스는 service 패키지 안에 위치해야 한다. */
+    @ArchTest
+    static final ArchRule SERVICES_RESIDE_IN_SERVICE_PACKAGE =
+            classes()
+                    .that()
+                    .haveSimpleNameEndingWith("Service")
+                    .and()
+                    .resideOutsideOfPackage(GLOBAL_PKG)
+                    .should()
+                    .resideInAPackage("..service..")
+                    .because("*Service 클래스는 service 패키지 안에 위치해야 합니다.");
+
+    /**
+     * *Repository 클래스는 repository 패키지 안에 위치해야 한다.
+     *
+     * <p>global 패키지(RefreshTokenRepository) 및 config 패키지(Spring Security OAuth2
+     * HttpCookieOAuth2AuthorizationRequestRepository 등)는 프레임워크 패턴상 예외 허용.
+     */
+    @ArchTest
+    static final ArchRule REPOSITORIES_RESIDE_IN_REPOSITORY_PACKAGE =
+            classes()
+                    .that()
+                    .haveSimpleNameEndingWith("Repository")
+                    .and()
+                    .resideOutsideOfPackage(GLOBAL_PKG)
+                    .and()
+                    .resideOutsideOfPackage("..config..")
+                    .should()
+                    .resideInAPackage("..repository..")
+                    .because("*Repository 클래스는 repository 패키지 안에 위치해야 합니다.");
+
+    // ============================================================
+    // 3. 이벤트 패키지 규칙  (feat/event-driven)
+    // ============================================================
+
+    /**
+     * Spring 도메인 이벤트(*Event)는 event 패키지 안에 위치해야 한다.
+     *
+     * <p>JPA @Entity 클래스(StampEvent, RedeemEvent 등 이력 엔티티)는 domain 패키지에 위치하므로 제외한다. 이 규칙은
+     * ApplicationEvent / 도메인 이벤트 POJO에 적용된다.
+     */
+    @ArchTest
+    static final ArchRule EVENTS_RESIDE_IN_EVENT_PACKAGE =
+            classes()
+                    .that()
+                    .haveSimpleNameEndingWith("Event")
+                    .and()
+                    .areNotAnnotatedWith(Entity.class)
+                    .should()
+                    .resideInAPackage("..event..")
+                    .allowEmptyShould(true)
+                    .because("*Event(도메인 이벤트 POJO)는 event 패키지 안에 위치해야 합니다.");
+
+    /** Controller에서 이벤트를 직접 발행하는 것을 금지한다. 이벤트 발행은 Service에서만 허용. */
+    @ArchTest
+    static final ArchRule CONTROLLERS_MUST_NOT_PUBLISH_EVENTS =
+            noClasses()
+                    .that()
+                    .resideInAPackage("..controller..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAPackage("..event..")
+                    .allowEmptyShould(true)
+                    .because("이벤트 발행은 Service 레이어에서만 허용됩니다.");
+
+    // ============================================================
+    // 4. 어노테이션 네이밍 일관성
+    // ============================================================
+
+    /**
+     * @Service 어노테이션은 이름이 Service로 끝나는 클래스에만 붙여야 한다.
+     *
+     * <p>유틸리티/헬퍼 클래스에 @Service를 붙이면 역할 혼동이 발생한다. @Component를 사용하거나 이름을 *Service로 변경하라.
+     */
+    @ArchTest
+    static final ArchRule SERVICE_ANNOTATION_ONLY_ON_SERVICE_CLASSES =
+            classes()
+                    .that()
+                    .areAnnotatedWith(Service.class)
+                    .should()
+                    .haveSimpleNameEndingWith("Service")
+                    .because("@Service는 *Service 이름을 가진 클래스에만 사용하세요. 유틸리티는 @Component를 쓰세요.");
+
+    /**
+     * @Repository 어노테이션은 이름이 Repository로 끝나는 클래스에만 붙여야 한다.
+     */
+    @ArchTest
+    static final ArchRule REPOSITORY_ANNOTATION_ONLY_ON_REPOSITORY_CLASSES =
+            classes()
+                    .that()
+                    .areAnnotatedWith(Repository.class)
+                    .should()
+                    .haveSimpleNameEndingWith("Repository")
+                    .because("@Repository는 *Repository 이름을 가진 클래스에만 사용하세요.");
+
+    // ============================================================
+    // 5. @Transactional 규칙
+    // ============================================================
+
+    /**
+     * Controller 메서드에 @Transactional 사용 금지.
+     *
+     * <p>HTTP 처리 전 과정(인증, 검증, 직렬화)이 트랜잭션에 묶여 커넥션 풀 고갈을 유발한다. 트랜잭션 경계는 Service 레이어에서 관리한다. global
+     * 패키지(TokenRefreshController)는 예외.
+     */
+    @ArchTest
+    static final ArchRule NO_TRANSACTIONAL_ON_CONTROLLERS =
+            noMethods()
+                    .that()
+                    .areDeclaredInClassesThat(
+                            resideInAPackage("..controller..")
+                                    .and(resideOutsideOfPackages(GLOBAL_PKG)))
+                    .should()
+                    .beAnnotatedWith(Transactional.class)
+                    .because(
+                            "Controller 메서드에 @Transactional을 사용하지 마세요."
+                                    + " 트랜잭션 경계는 Service에서 관리합니다.");
+
+    // ============================================================
+    // 6. 순환 의존성 금지
+    // ============================================================
+
+    // ============================================================
+    // 6. 순환 의존성 금지
+    // ============================================================
+
+    /**
+     * 피처 패키지 간 순환 의존 금지.
+     *
+     * <p>현재 비활성화 상태: CustomerWalletService가 redeem/stamp/stampcard/store를 직접 임포트하여 순환이 발생한다 (redeem
+     * → stampcard → store → wallet → redeem). feat/event-driven 작업에서 직접 임포트를 이벤트 발행/구독으로 교체하면 이 규칙을
+     * 활성화한다. 활성화 방법: 아래 주석을 해제하고 @ArchTest 어노테이션 추가.
+     *
+     * <pre>
+     * TODO(feat/event-driven): CustomerWalletService에서 redeem/stamp/stampcard/store 직접 의존 제거 후 활성화
+     * </pre>
+     */
+    static final ArchRule NO_CYCLIC_FEATURE_DEPENDENCIES =
+            SlicesRuleDefinition.slices()
+                    .matching(
+                            "com.project.kkookk."
+                                    + "(admin|issuance|migration|oauth|owner|qrcode"
+                                    + "|redeem|stamp|stampcard|statistics|store|wallet)..")
+                    .should()
+                    .beFreeOfCycles()
+                    .because("피처 패키지 간 순환 의존성은 유지보수를 어렵게 만듭니다." + " 공통 로직은 global 패키지로 추출하세요.");
+}

--- a/backend/src/test/java/com/project/kkookk/architecture/TestingConventionsTest.java
+++ b/backend/src/test/java/com/project/kkookk/architecture/TestingConventionsTest.java
@@ -1,0 +1,44 @@
+package com.project.kkookk.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+/**
+ * 테스트 코드 컨벤션 규칙.
+ *
+ * <p>프로덕션 코드가 아닌 테스트 코드에만 적용되는 규칙을 검증한다.
+ */
+@AnalyzeClasses(
+        packages = "com.project.kkookk",
+        importOptions = ImportOption.OnlyIncludeTests.class)
+class TestingConventionsTest {
+
+    /**
+     * @MockBean 사용 금지. @MockitoBean을 사용해야 한다.
+     *
+     * <p>@MockBean은 Spring Boot 3.4+에서 deprecated. 매번 Spring Context를 재생성해 테스트 속도가
+     * 저하된다. @MockitoBean은 Context를 재사용하면서 Bean만 교체한다.
+     */
+    @ArchTest
+    static final ArchRule NO_MOCK_BEAN =
+            noFields()
+                    .should()
+                    .beAnnotatedWith(MockBean.class)
+                    .because("@MockBean 대신 @MockitoBean을 사용하세요. (CLAUDE.md 참조)");
+
+    /**
+     * @SpyBean 사용 금지. @MockitoSpyBean을 사용해야 한다.
+     */
+    @ArchTest
+    static final ArchRule NO_SPY_BEAN =
+            noFields()
+                    .should()
+                    .beAnnotatedWith(SpyBean.class)
+                    .because("@SpyBean 대신 @MockitoSpyBean을 사용하세요. (CLAUDE.md 참조)");
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #

## 📌 작업 내용 요약

Claude Code가 생성하는 코드의 아키텍처 규칙 위반을 **빌드 단계에서 자동 차단**하는 안전망을 구축했습니다.
CLAUDE.md를 교과서(읽는 것)로만 두는 게 아니라, ArchUnit + Checkstyle을 **시험지(위반 시 빌드 실패)**로 활용합니다.

## 🚀 변경 사항

### As-Is | 문제 상황
- Claude Code가 CLAUDE.md 가이드라인을 읽고 코드를 생성하지만, 규칙 준수 여부를 자동으로 검증하는 수단이 없었음
- 아키텍처 위반(레이어 의존성, 패키지 위치, 금지 어노테이션 등)을 코드 리뷰에서 **사람이 직접** 발견해야 함

### Process | 도입 내용

**ArchUnit** (`archunit-junit5:1.3.0`) — JUnit 테스트로 아키텍처 규칙 자동 검증

| 테스트 클래스 | 규칙 |
|---|---|
| `ArchitectureTest` | 레이어 의존성, 패키지 위치, 이벤트 패키지, 어노테이션 네이밍, `@Transactional` 10개 규칙 |
| `TestingConventionsTest` | `@MockBean` / `@SpyBean` 사용 시 빌드 실패 → `@MockitoBean` 강제 |

**Checkstyle 강화**
- `jakarta.transaction.Transactional` 임포트 금지 → `org.springframework.transaction.annotation.Transactional` 사용 강제

**자기 수정 루프**
```
Claude가 코드 작성
  → ./gradlew test 실패
  → 에러: "Controller → Repository 직접 접근 금지. Service를 통해 접근하세요."
  → Claude가 메시지를 읽고 스스로 수정
```

> **ADR**: `NO_CYCLIC_FEATURE_DEPENDENCIES` 규칙은 기존 순환 의존 기술 부채(`redeem → stampcard → store → wallet → redeem`) 때문에 `@ArchTest` 비활성화. `feat/event-driven`에서 직접 임포트를 이벤트 발행/구독으로 교체 완료 후 활성화 예정.

### To-Be | 기대 효과
- 아키텍처 규칙 위반이 **PR 이전 단계**에서 자동 차단
- 에러 메시지가 곧 수정 가이드 → 리뷰 코멘트 감소
- `feat/event-driven` 완료 후 순환 의존 규칙까지 활성화

## 🔎 리뷰 요구사항 (선택)

- 비활성화된 `NO_CYCLIC_FEATURE_DEPENDENCIES` 규칙의 활성화 시점이 적절한지 의견 부탁드립니다.
- ArchUnit 예외 처리 범위(`GLOBAL_PKG`, `..config..`)가 충분한지 확인 부탁드립니다.

## 📎 참고 자료 (선택)

- [ArchUnit 공식 문서](https://www.archunit.org)
- 참고: Musinsa 기술 블로그 — AI 코드 품질 자동화 (시험지 vs 교과서 개념)